### PR TITLE
chore(ci): upgrade labeler v5→v6 + add pr-size labeler + dependabot bumps

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -18,3 +18,4 @@ jobs:
             - uses: actions/labeler@v6
               with:
                   repo-token: ${{ secrets.GITHUB_TOKEN }}
+                  sync-labels: true

--- a/.github/workflows/pull-request-size.yml
+++ b/.github/workflows/pull-request-size.yml
@@ -1,0 +1,25 @@
+---
+name: Label Pull Request Size
+
+on:
+    pull_request:
+        types: [opened, reopened, synchronize]
+
+permissions:
+    contents: read
+    pull-requests: write
+
+jobs:
+    size-label:
+        runs-on: ubuntu-latest
+        name: Label PR by size
+        steps:
+            - name: Label pull request by size
+              uses: codelytv/pr-size-labeler@v1
+              with:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  xs_max_size: 20
+                  s_max_size: 50
+                  m_max_size: 200
+                  l_max_size: 800
+                  fail_if_xl: false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,10 @@
 # CLAUDE.md — project-init
 
+> @[claude-sonnet-4-6]
+
 ## Project Overview
 
-`project-init` is the **project bootstrap and initializer** for the chrysa ecosystem.
+`project-init` is the **project bootstrap and initializer** for the ecosystem.
 
 Its purpose is to automate repetitive, error-prone project setup work so every new repository starts
 with standards enforced, CI wired, pre-commit configured, Claude Code integrated, and documentation

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # project-init
 
-> **Project bootstrap and initializer for the chrysa ecosystem.**
+> **Project bootstrap and initializer for the ecosystem.**
 
 `project-init` rationalizes project creation, enforces standards from day one, and automates the repetitive setup work that every new repository needs.
 
 ## Purpose
 
-Every new project in the chrysa ecosystem needs the same set of things:
+Every new project in the ecosystem needs the same set of things:
 - CI/CD pipeline (GitHub Actions)
 - Pre-commit hooks
 - Makefile


### PR DESCRIPTION
## Changes
- Upgrade `actions/labeler` v5 → v6 (breaking: new config format)
- Add `pr-size` labeler (XS/S/M/L/XL based on lines changed)
- Bump `actions/setup-python` 5→6, `actions/github-script` 7→8, `actions/checkout` 4→6
- Add PR template + issue templates (bug, feature, chore)
- Add `copilot-instructions.md` and `dependabot.yml`
- CI workflow standardization

## Type
chore