### PR TITLE
chore(quality): apply pre-commit auto-fixes on main

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,64 +1,64 @@
 {
-  "effortLevel": "medium",
   "autoCompact": true,
   "autoCompactThreshold": 0.85,
+  "effortLevel": "medium",
   "hooks": {
-    "PreCompact": [
+    "Notification": [
       {
-        "type": "command",
-        "command": "~/.claude/hooks/pre-compact.sh",
-        "timeout": 5000
-      }
-    ],
-    "PreToolUse": [
-      {
-        "matcher": "Bash",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "node .claude/hooks/secret-scanner.cjs",
-            "name": "secret-scanner",
-            "timeout": 10000
-          },
-          {
-            "type": "command",
-            "command": "node .claude/hooks/circuit-breaker.cjs",
-            "name": "circuit-breaker",
-            "timeout": 5000
-          }
-        ]
+        "command": "notify-send 'Claude Code' 'En attente de ton input' 2>/dev/null || true",
+        "timeout": 3000,
+        "type": "command"
       }
     ],
     "PostToolUse": [
       {
-        "matcher": "Write|Edit|MultiEdit",
         "hooks": [
           {
-            "type": "command",
             "command": "node .claude/hooks/verifiable-thresholds.cjs",
             "name": "verifiable-thresholds",
-            "timeout": 10000
+            "timeout": 10000,
+            "type": "command"
           }
-        ]
+        ],
+        "matcher": "Write|Edit|MultiEdit"
+      }
+    ],
+    "PreCompact": [
+      {
+        "command": "~/.claude/hooks/pre-compact.sh",
+        "timeout": 5000,
+        "type": "command"
+      }
+    ],
+    "PreToolUse": [
+      {
+        "hooks": [
+          {
+            "command": "node .claude/hooks/secret-scanner.cjs",
+            "name": "secret-scanner",
+            "timeout": 10000,
+            "type": "command"
+          },
+          {
+            "command": "node .claude/hooks/circuit-breaker.cjs",
+            "name": "circuit-breaker",
+            "timeout": 5000,
+            "type": "command"
+          }
+        ],
+        "matcher": "Bash"
       }
     ],
     "UserPromptSubmit": [
       {
         "hooks": [
           {
-            "type": "command",
             "command": "node .claude/hooks/frustration-detection.cjs",
             "name": "frustration-detection",
-            "timeout": 5000
+            "timeout": 5000,
+            "type": "command"
           }
         ]
-      }
-    ],
-    "Notification": [
-      {
-        "type": "command",
-        "command": "notify-send 'Claude Code' 'En attente de ton input' 2>/dev/null || true",
-        "timeout": 3000
       }
     ]
   }

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,7 +17,7 @@ Closes #<!-- issue number — required: 1 PR = 1 issue -->
 
 ## Changes
 <!-- List the concrete changes made -->
-- 
+-
 
 ## Dependencies
 <!-- PRs this depends on (must be merged first). Format: chrysa/REPO#NUMBER -->


### PR DESCRIPTION
## Summary
- Remove trailing whitespace in `.github/pull_request_template.md`
- Sort JSON keys in `.claude/settings.json` (json-sorter hook)

## Why
The `Lint & validate` CI job currently fails on `main` because `pre-commit run --all-files` produces modifications (trailing whitespace + JSON key ordering). This blocks any follow-up PR (including #20 and #22).

Applying the auto-fixes unblocks the pipeline with zero behaviour change.

## Test plan
- [x] `pre-commit run --all-files` passes locally
- [ ] CI `Lint & validate` turns green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)