### PR TITLE
ci(pre-commit): bump chrysa/pre-commit-tools to v0.1.1-73

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
             args: [--fix]
             stages: [manual]
     - repo: https://github.com/chrysa/pre-commit-tools
-      rev: v0.1.1-72
+      rev: v0.1.1-73
       hooks:
           - id: yaml-sorter
             exclude: ^(\.github/)


### PR DESCRIPTION
Bump to v0.1.1-73. New: adr-gate hook (chrysa/pre-commit-tools#135).