### PR TITLE
ci: update to Python 3.14 and chrysa/github-actions composites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,8 @@ jobs:
 
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: "3.14"
+          cache: pip
 
       - name: Run pre-commit hooks
         uses: pre-commit/action@v3.0.1


### PR DESCRIPTION
Update CI to use Python 3.14 and add pip cache:
- `setup-python`: 3.12 → 3.14 + `cache: pip`
- Aligns with ecosystem Python version standard