### PR TITLE
ci: migrate CI workflows to use github-actions composite actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,8 @@ jobs:
 
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: "3.14"
+          cache: pip
 
       - name: Run pre-commit hooks
         uses: pre-commit/action@v3.0.1


### PR DESCRIPTION
## Summary
Replace inline CI steps with reusable composite actions from `chrysa/github-actions`.

- Reduces duplication across repos
- Ensures consistent CI behavior across the ecosystem
- Easier to update CI logic in one place