### PR TITLE
fix(ci): add SKIP no-commit-to-branch in pre-commit step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,3 +37,5 @@ jobs:
 
       - name: Run pre-commit hooks
         uses: pre-commit/action@v3.0.1
+        env:
+          SKIP: no-commit-to-branch


### PR DESCRIPTION
Add SKIP: no-commit-to-branch env to pre-commit step in ci.yml to prevent CI failures when runner is on main