### PR TITLE
fix(ci): downgrade sonarqube-scan-action v8->v4.2.1 for SonarCloud

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -23,7 +23,7 @@ jobs:
               with:
                   fetch-depth: 0
             - name: SonarCloud scan
-              uses: SonarSource/sonarqube-scan-action@v8.0.0
+              uses: SonarSource/sonarqube-scan-action@v4.2.1
               with:
                   args: >
                       -Dsonar.projectKey=chrysa_project-init


### PR DESCRIPTION
- SonarSource/sonarqube-scan-action v8.0.0 → v4.2.1
- Scanner 8.x incompatible with SonarCloud (Error 404 /analysis/analyses)
- v4.2.1 uses sonar-scanner-cli 5.x, known stable with SonarCloud