### PR TITLE
chore: add standards compliance files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,22 @@
+# CODEOWNERS
+# Default owner for all files
+* @chrysa
+
+# Backend / Python source
+/backend/ @chrysa
+/src/ @chrysa
+/api/ @chrysa
+/code/ @chrysa
+
+# Frontend / Node source
+/frontend/ @chrysa
+
+# Infrastructure / CI
+/.github/ @chrysa
+/Dockerfile @chrysa
+/docker-compose*.yml @chrysa
+/k8s/ @chrysa
+
+# Documentation
+*.md @chrysa
+/docs/ @chrysa


### PR DESCRIPTION
## Summary

Add missing ecosystem standards compliance files:

- `.github/CODEOWNERS` — ownership rules (`* @chrysa`)
- `sonar-project.properties` — SonarCloud project config
- `.github/dependabot.yml` — automated dependency updates
- `cliff.toml` — git-cliff changelog generation config
- `.pre-commit-config.yaml` — pre-commit hooks (regression-gate, secret scanning)

Part of the chrysa ecosystem-wide standards enforcement initiative.

## Checklist
- [x] All required files present
- [x] No functional code changed
- [x] CODEOWNERS set to `@chrysa`
