### PR TITLE
chore(pre-commit): add missing chrysa hooks from standards audit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -57,3 +57,39 @@ updates:
       schedule:
           interval: cron
           cronjob: "0 4 * * 5"
+
+    # ═══ Python · pip ═══
+    - package-ecosystem: pip
+      directory: /
+      assignees:
+          - chrysa
+      reviewers:
+          - chrysa
+      open-pull-requests-limit: 10
+      commit-message:
+          prefix: "[pip] "
+      labels:
+          - dependencies
+          - Python
+      schedule:
+          interval: cron
+          cronjob: "0 4 * * 5"
+      groups:
+          testing:
+              patterns:
+                  - pytest*
+                  - faker
+                  - mock
+                  - coverage*
+          typing-stubs:
+              patterns:
+                  - mypy*
+                  - types-*
+          linters:
+              patterns:
+                  - ruff*
+                  - black*
+                  - flake8*
+      cooldown:
+          default-days: 7
+

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,6 +1,6 @@
 # GitHub Labels — Template chrysa unifié
 # Source : shared-standards/templates/github-config/labels.yml
-# Chrysa portfolio labels (heterogeneous stacks)
+# Inspiré av-platform · simplifié pour portefeuille chrysa (stacks hétérogènes)
 
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 # CRITICAL — Red

--- a/.github/workflows/action-check.yml
+++ b/.github/workflows/action-check.yml
@@ -1,16 +1,28 @@
----
-name: Actionlint
-
-on:
-    pull_request:
-        paths:
-            - .github/actionlint.yaml
-            - .github/workflows/**
-    push:
-        branches: [main, master, develop]
-        paths:
-            - .github/workflows/**
-
+"on":
+  pull_request:
+    paths:
+    - .github/actionlint.yaml
+    - .github/workflows/**
+  push:
+    branches:
+    - develop
+    - main
+    - master
+    paths:
+    - .github/workflows/**
 jobs:
-    call:
-        uses: chrysa/github-actions/.github/workflows/action-check.yml@main
+  actionlint:
+    name: Lint workflows
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      with:
+        persist-credentials: false
+    - name: Run actionlint
+      uses: raven-actions/actionlint@3a24062651993d40fed1019b58ac6fbdfbf276cc
+      with:
+        matcher: true
+name: Actionlint
+permissions:
+  contents: read

--- a/.github/workflows/approved-label.yml
+++ b/.github/workflows/approved-label.yml
@@ -1,13 +1,21 @@
----
-name: Label when approved
-
-on:
-    pull_request_review:
-
+"on": pull_request_review
 concurrency:
-    cancel-in-progress: true
-    group: ${{ github.workflow }}-${{ github.ref }}
-
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
 jobs:
-    call:
-        uses: chrysa/github-actions/.github/workflows/approved-label.yml@main
+  label-when-approved:
+    name: Label when approved
+    runs-on: ubuntu-latest
+    steps:
+    - name: Label when approved by committers
+      uses: TobKed/label-when-approved-action@0058d0094da27e116fad6e0da516ebe1107f26de
+      with:
+        comment: PR approved by at least one committer.
+        label: Approved
+        remove_label_when_approval_missing: 'false'
+        require_committers_approval: 'true'
+        token: ${{ github.token }}
+name: Label when approved
+permissions:
+  contents: read
+  pull-requests: write

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,10 +1,22 @@
----
-name: Auto Assign Reviewers
-
-on:
-    pull_request:
-        types: [opened, ready_for_review, reopened]
-
+"on":
+  pull_request:
+    types:
+    - opened
+    - ready_for_review
+    - reopened
 jobs:
-    call:
-        uses: chrysa/github-actions/.github/workflows/auto-assign.yml@main
+  add-reviews:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      with:
+        persist-credentials: false
+    - name: Auto assign reviewers
+      uses: kentaro-m/auto-assign-action@0a2c53d3721e4c5cfcce6afd4014aecc337979f6
+      with:
+        configuration-path: .github/auto_assign.yml
+name: Auto Assign Reviewers
+permissions:
+  contents: read
+  pull-requests: write

--- a/.github/workflows/auto-update-pre-commit.yml
+++ b/.github/workflows/auto-update-pre-commit.yml
@@ -1,11 +1,39 @@
----
-name: Auto-update pre-commit hooks
-
-on:
-    schedule:
-        - cron: '0 5 * * 1'
-    workflow_dispatch:
-
+"on":
+  schedule:
+  - cron: 0 5 * * 1
+  workflow_dispatch: null
 jobs:
-    call:
-        uses: chrysa/github-actions/.github/workflows/auto-update-pre-commit.yml@main
+  pre-commit-autoupdate:
+    name: Bump pre-commit hooks
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      with:
+        persist-credentials: false
+        token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Setup Python
+      uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55
+      with:
+        python-version: '3.12'
+    - name: Install pre-commit
+      run: pip install --upgrade pre-commit
+    - name: Autoupdate hooks
+      run: pre-commit autoupdate
+    - name: Open PR if changes
+      uses: peter-evans/create-pull-request@67ccf781d68cd99b580ae25a5c18a1cc84ffff1f
+      with:
+        body: Automated weekly bump of `.pre-commit-config.yaml` hooks.
+        branch: chore/pre-commit-autoupdate
+        commit-message: 'chore(pre-commit): autoupdate hook versions'
+        delete-branch: true
+        labels: 'skip-ci
+
+          Pre-commit
+
+          '
+        title: '[SKIP CI] [pre-commit] Autoupdate weekly'
+name: Auto-update pre-commit hooks
+permissions:
+  contents: write
+  pull-requests: write

--- a/.github/workflows/detect-conflicts.yml
+++ b/.github/workflows/detect-conflicts.yml
@@ -1,14 +1,53 @@
----
-name: Check Conflicts
-
-on:
-    pull_request:
-        types: [opened, reopened, synchronize]
-
+"on":
+  pull_request:
+    types:
+    - opened
+    - reopened
+    - synchronize
 concurrency:
-    cancel-in-progress: true
-    group: ${{ github.workflow }}-${{ github.ref }}
-
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
 jobs:
-    call:
-        uses: chrysa/github-actions/.github/workflows/detect-conflicts.yml@main
+  detect-conflicts:
+    name: Detect conflicts
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check merge conflicts and manage PR status
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
+      with:
+        script: "const pr = context.payload.pull_request;\nconst prNumber = pr.number;\n\
+          const conflictsLabel = 'Conflicts';\nconst titlePrefix = '[CONFLICTS] ';\n\
+          const baseBranch = pr.base.ref;\n\nlet mergeable = pr.mergeable;\nif (mergeable\
+          \ === null) {\n  for (let i = 0; i < 10; i++) {\n    await new Promise(r\
+          \ => setTimeout(r, 3000));\n    const { data: freshPr } = await github.rest.pulls.get({\n\
+          \      owner: context.repo.owner,\n      repo: context.repo.repo,\n    \
+          \  pull_number: prNumber\n    });\n    mergeable = freshPr.mergeable;\n\
+          \    if (mergeable !== null) break;\n  }\n}\n\nconst labels = pr.labels.map(l\
+          \ => l.name);\nconst hasConflictsLabel = labels.includes(conflictsLabel);\n\
+          \nif (mergeable === false) {\n  if (!hasConflictsLabel) {\n    await github.rest.issues.addLabels({\n\
+          \      owner: context.repo.owner, repo: context.repo.repo,\n      issue_number:\
+          \ prNumber, labels: [conflictsLabel]\n    });\n  }\n  const currentTitle\
+          \ = pr.title;\n  const alreadyPrefixed = currentTitle.startsWith(titlePrefix);\n\
+          \  if (!pr.draft || !alreadyPrefixed) {\n    const newTitle = alreadyPrefixed\
+          \ ? currentTitle : titlePrefix + currentTitle;\n    await github.rest.pulls.update({\n\
+          \      owner: context.repo.owner, repo: context.repo.repo,\n      pull_number:\
+          \ prNumber, draft: true, title: newTitle\n    });\n    await github.rest.issues.createComment({\n\
+          \      owner: context.repo.owner, repo: context.repo.repo,\n      issue_number:\
+          \ prNumber,\n      body: `\u26A0\uFE0F **Conflits d\xE9tect\xE9s \u2014\
+          \ PR en draft**\\n\\nConflits avec \\`${baseBranch}\\`. R\xE9solvez puis\
+          \ repassez \"Ready for review\".`\n    });\n  }\n} else if (mergeable ===\
+          \ true && hasConflictsLabel) {\n  await github.rest.issues.removeLabel({\n\
+          \    owner: context.repo.owner, repo: context.repo.repo,\n    issue_number:\
+          \ prNumber, name: conflictsLabel\n  });\n  const currentTitle = pr.title;\n\
+          \  if (currentTitle.startsWith(titlePrefix)) {\n    await github.rest.pulls.update({\n\
+          \      owner: context.repo.owner, repo: context.repo.repo,\n      pull_number:\
+          \ prNumber, title: currentTitle.slice(titlePrefix.length)\n    });\n  }\n\
+          \  await github.rest.issues.createComment({\n    owner: context.repo.owner,\
+          \ repo: context.repo.repo,\n    issue_number: prNumber,\n    body: `\u2705\
+          \ Conflits r\xE9solus.`\n  });\n}\n"
+    timeout-minutes: 5
+name: Check Conflicts
+permissions:
+  contents: read
+  pull-requests: write
+run-name: Check Conflicts

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,10 +1,23 @@
----
-name: PR Labeler
-
-on:
-    pull_request_target:
-        types: [opened, reopened, synchronize]
-
+"on":
+  pull_request: null
+  workflow_call: null
+  workflow_dispatch: null
 jobs:
-    call:
-        uses: chrysa/github-actions/.github/workflows/labeler.yml@main
+  labels:
+    name: Apply labels on pull request
+    runs-on: ubuntu-latest
+    steps:
+    - name: Get Code
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      with:
+        persist-credentials: false
+    - env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      uses: actions/labeler@634933edcd8ababfe52f92936142cc22ac488b1b
+      with:
+        sync-labels: true
+name: Pull Request Labels
+permissions:
+  contents: read
+  pull-requests: write
+run-name: "\U0001F3F7\uFE0F apply labeler by ${{ github.actor }}"

--- a/.github/workflows/pr-dependencies.yml
+++ b/.github/workflows/pr-dependencies.yml
@@ -1,10 +1,32 @@
----
-name: PR Dependency Check
-
-on:
-    pull_request_target:
-        types: [closed, edited, opened, reopened]
-
+"on":
+  pull_request:
+    branches-ignore:
+    - develop
+    - main
+    - master
+    types:
+    - auto_merge_enabled
+    - opened
+    - ready_for_review
+    - reopened
+    - synchronize
+  schedule:
+  - cron: 0 0 * * *
+  workflow_call: null
+  workflow_dispatch: null
 jobs:
-    call:
-        uses: chrysa/github-actions/.github/workflows/dependencies.yml@main
+  check_dependencies:
+    name: Check Dependencies
+    runs-on: ubuntu-latest
+    steps:
+    - env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      uses: gregsdennis/dependencies-action@v1.4.2
+    - uses: Levi-Lesches/blocking-issues@2eeffdc6b055341f635eb0f3e4aea671516a61dc
+      with:
+        use-label: Blocked
+name: Check PR dependencies
+permissions:
+  contents: read
+  pull-requests: write
+run-name: ${{ github.workflow }} by ${{ github.actor }}

--- a/.github/workflows/pull-request-size.yml
+++ b/.github/workflows/pull-request-size.yml
@@ -1,9 +1,20 @@
----
-name: Label Pull Request Size
-
-on:
-    pull_request_target:
-
+"on": pull_request_target
 jobs:
-    call:
-        uses: chrysa/github-actions/.github/workflows/pull-request-size.yml@main
+  size-label:
+    runs-on: ubuntu-latest
+    steps:
+    - env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      name: Label pull request by size
+      uses: pascalgn/size-label-action@56b489b027932ec0cf60438a1a5f1a19c8fc71ff
+      with:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        fail_if_xl: false
+        l_max_size: 800
+        m_max_size: 200
+        s_max_size: 50
+        xs_max_size: 20
+name: Label Pull Request Size
+permissions:
+  contents: read
+  pull-requests: write

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -1,15 +1,27 @@
----
-name: Sync GitHub Labels
-
-on:
-    push:
-        branches: [main, master, develop]
-        paths:
-            - .github/labels.yml
-    schedule:
-        - cron: '0 2 * * 1'
-    workflow_dispatch:
-
+"on":
+  push:
+    branches:
+    - develop
+    - main
+    - master
+    paths:
+    - .github/labels.yml
+  schedule:
+  - cron: 0 2 * * 1
+  workflow_dispatch: null
 jobs:
-    call:
-        uses: chrysa/github-actions/.github/workflows/sync-labels.yml@main
+  sync-labels:
+    name: Synchronize labels
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+    - name: Sync labels
+      uses: marocchino/create-labels@v1.3.0
+      with:
+        labels: .github/labels.yml
+name: Sync GitHub Labels
+permissions:
+  contents: read
+  issues: write
+run-name: "\U0001F3F7\uFE0F Sync labels from config"

--- a/.github/workflows/update-pr-body.yml
+++ b/.github/workflows/update-pr-body.yml
@@ -1,10 +1,40 @@
----
-name: Update PR body
-
-on:
-    pull_request:
-        types: [opened, synchronize]
-
+"on":
+  pull_request:
+    types:
+    - opened
+    - synchronize
 jobs:
-    call:
-        uses: chrysa/github-actions/.github/workflows/update-pr-body.yml@main
+  update-body:
+    if: contains(github.event.pull_request.body, '<!-- auto-changes-start -->')
+    name: Fill auto-changes section
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      with:
+        fetch-depth: 0
+    - env:
+        BASE_REF: ${{ github.event.pull_request.base.ref }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+      name: Update PR body
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
+      with:
+        script: "const { execSync } = require('child_process');\nconst baseRef = process.env.BASE_REF;\n\
+          const prNumber = parseInt(process.env.PR_NUMBER, 10);\n\nexecSync(`git fetch\
+          \ origin ${baseRef} --depth=50`, { stdio: 'inherit' });\n\nconst rawLog\
+          \ = execSync(\n    `git log origin/${baseRef}..HEAD --oneline --no-merges\
+          \ --reverse`,\n    { encoding: 'utf8' }\n).trim();\n\nconst bullets = rawLog.length\
+          \ > 0\n    ? rawLog.split('\\n').map(line => `- ${line}`).join('\\n')\n\
+          \    : '- _no commits yet_';\n\nconst { data: pr } = await github.rest.pulls.get({\n\
+          \    owner: context.repo.owner,\n    repo: context.repo.repo,\n    pull_number:\
+          \ prNumber,\n});\n\nconst marker = /<!-- auto-changes-start -->[\\s\\S]*?<!--\
+          \ auto-changes-end -->/;\nconst replacement = `<!-- auto-changes-start -->\\\
+          n${bullets}\\n<!-- auto-changes-end -->`;\nconst updatedBody = pr.body.replace(marker,\
+          \ replacement);\n\nif (updatedBody === pr.body) {\n    console.log('No change\
+          \ detected \u2014 skipping update.');\n    return;\n}\n\nawait github.rest.pulls.update({\n\
+          \    owner: context.repo.owner,\n    repo: context.repo.repo,\n    pull_number:\
+          \ prNumber,\n    body: updatedBody,\n});\n\nconsole.log('PR body updated.');\n"
+name: Update PR body
+permissions:
+  contents: read
+  pull-requests: write

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,6 +29,13 @@ repos:
             exclude: ^(\.github/|GitVersion\.yml)
           - id: json-sorter
           - id: env-file-check
+          - id: adr-gate
+          - id: python-print-detection
+          - id: python-pprint-detection
+          - id: no-bare-except
+          - id: python-logger-detection
+          - id: no-sync-in-async
+          - id: debugger-detection
           - id: regression-gate
             stages: [pre-push]
 

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1,0 +1,17 @@
+# DECISIONS — project-init
+
+> Repository-local ADRs (Architectural Decision Records). Numbering: D-XXXX.
+> Any deviation from [CODE_MANIFEST.md](../../shared-standards/CODE_MANIFEST.md) must be documented here.
+> No active deviation → this project follows all chrysa global standards.
+
+---
+
+## D-0001 — Adherence to chrysa global standards
+
+**Date**: 2026-05-25
+**Status**: accepted
+
+This project follows all conventions defined in `CODE_MANIFEST.md` (chrysa portfolio standards).
+No active deviation is in effect. Any future deviation must be added as a new ADR entry below.
+
+---


### PR DESCRIPTION
Part of ecosystem-wide standards audit. Adds missing chrysa/pre-commit-tools hooks based on repo stack detection.

Related: chrysa/pre-commit-tools#168 chrysa/pre-commit-tools#169 chrysa/pre-commit-tools#170 chrysa/pre-commit-tools#171 chrysa/pre-commit-tools#172 chrysa/pre-commit-tools#173