### PR TITLE
fix(claude): wrap PreCompact/Notification hooks in hooks array

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,9 +5,13 @@
   "hooks": {
     "Notification": [
       {
-        "command": "notify-send 'Claude Code' 'En attente de ton input' 2>/dev/null || true",
-        "timeout": 3000,
-        "type": "command"
+        "hooks": [
+          {
+            "command": "notify-send 'Claude Code' 'En attente de ton input' 2>/dev/null || true",
+            "timeout": 3000,
+            "type": "command"
+          }
+        ]
       }
     ],
     "PostToolUse": [
@@ -25,9 +29,13 @@
     ],
     "PreCompact": [
       {
-        "command": "~/.claude/hooks/pre-compact.sh",
-        "timeout": 5000,
-        "type": "command"
+        "hooks": [
+          {
+            "command": "~/.claude/hooks/pre-compact.sh",
+            "timeout": 5000,
+            "type": "command"
+          }
+        ]
       }
     ],
     "PreToolUse": [


### PR DESCRIPTION
`claude doctor` reported **Invalid settings → hooks: Expected array, but received undefined**. The `PreCompact` / `Notification` hook events stored a bare command object instead of the required `{ "hooks": [ ... ] }` wrapper. This wraps them correctly. Config-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)