### PR TITLE
ci(secret-scan): use reusable workflow (fixes gitleaks 403 perms)

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -7,6 +7,10 @@ on:
     pull_request:
         branches: [main, develop, master]
 
+permissions:
+    contents: read
+    pull-requests: read
+
 jobs:
     call:
         uses: chrysa/github-actions/.github/workflows/secret-scan.yml@main


### PR DESCRIPTION
## What
Replace the vendored standalone `secret-scan.yml` with a call to the reusable `chrysa/github-actions/.github/workflows/secret-scan.yml@main`.

## Why
The standalone copy declared `permissions: contents: read` only, so `gitleaks-action@v2` got a **403** listing PR commits, failing the *Detect secrets* check on every PR. The reusable workflow now grants `pull-requests: read` (chrysa/github-actions#98) and is the single source of truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)