### PR TITLE
docs: adopt standardized documentation structure (stubs)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -92,4 +92,3 @@ updates:
                   - flake8*
       cooldown:
           default-days: 7
-

--- a/README.md
+++ b/README.md
@@ -69,3 +69,19 @@ See [ADR-001](docs/adr/ADR-001-architecture.md) for the full architecture decisi
 ## Status
 
 Early planning phase. See issues for the work breakdown.
+
+
+## Documentation map
+
+This repo follows the chrysa standardized documentation structure
+(`chrysa/shared-standards/templates/docs-structure`):
+
+- [`docs/`](docs/) — product, architecture, security, deployment, observability (stubs)
+- [`ai/`](ai/), [`prompts/`](prompts/) — AI assets & agent prompts
+- [`schemas/`](schemas/) — JSON Schema data contracts
+- [`workflows/`](workflows/) — end-to-end flow docs
+- [`decisions/`](decisions/), [`postmortems/`](postmortems/) — decision records & incident postmortems
+- [`examples/`](examples/) — reference “perfect” implementations
+- [`tests/`](tests/) — test scenario catalogues
+
+Files marked `status: stub` are placeholders to fill in.

--- a/ai/CLAUDE.md
+++ b/ai/CLAUDE.md
@@ -1,0 +1,11 @@
+---
+title: AI Agent Context (pointer)
+status: pointer
+---
+
+# AI Agent Context
+
+Canonical agent context lives at the repo root:
+[`../CLAUDE.md`](../CLAUDE.md) (Claude Code) and [`../AGENTS.md`](../AGENTS.md) (generic agents).
+
+This `ai/` directory holds supporting assets only — see `prompt-library.md` and `evaluation-datasets.md`.

--- a/ai/evaluation-datasets.md
+++ b/ai/evaluation-datasets.md
@@ -1,0 +1,17 @@
+---
+title: Evaluation Datasets
+status: stub
+owner: TODO
+last-reviewed: TODO
+---
+
+# Evaluation Datasets
+
+## Purpose
+
+Datasets and rubrics used to evaluate AI features (golden sets, edge cases, scoring).
+
+## TODO
+
+- [ ] Fill in this document for the project.
+- [ ] Remove the `status: stub` marker once populated.

--- a/ai/prompt-library.md
+++ b/ai/prompt-library.md
@@ -1,0 +1,17 @@
+---
+title: Prompt Library
+status: stub
+owner: TODO
+last-reviewed: TODO
+---
+
+# Prompt Library
+
+## Purpose
+
+Reusable, versioned prompts used by the app's AI features. One section per prompt with inputs/outputs.
+
+## TODO
+
+- [ ] Fill in this document for the project.
+- [ ] Remove the `status: stub` marker once populated.

--- a/decisions/DEC-001-auth-provider.md
+++ b/decisions/DEC-001-auth-provider.md
@@ -1,0 +1,16 @@
+---
+id: DEC-001
+title: Auth provider choice
+status: example
+date: TODO
+---
+
+# DEC-001 — Auth provider choice
+
+> **EXAMPLE** — illustrative stub. Replace with a real decision or delete.
+
+## Context
+
+## Decision
+
+## Consequences

--- a/decisions/DEC-002-db-choice.md
+++ b/decisions/DEC-002-db-choice.md
@@ -1,0 +1,16 @@
+---
+id: DEC-002
+title: Database choice
+status: example
+date: TODO
+---
+
+# DEC-002 — Database choice
+
+> **EXAMPLE** — illustrative stub. Replace with a real decision or delete.
+
+## Context
+
+## Decision
+
+## Consequences

--- a/decisions/DEC-003-cache-strategy.md
+++ b/decisions/DEC-003-cache-strategy.md
@@ -1,0 +1,16 @@
+---
+id: DEC-003
+title: Cache strategy
+status: example
+date: TODO
+---
+
+# DEC-003 — Cache strategy
+
+> **EXAMPLE** — illustrative stub. Replace with a real decision or delete.
+
+## Context
+
+## Decision
+
+## Consequences

--- a/decisions/_TEMPLATE.md
+++ b/decisions/_TEMPLATE.md
@@ -1,0 +1,16 @@
+---
+id: DEC-NNN
+title: TODO
+status: proposed   # proposed | accepted | superseded | rejected
+date: TODO
+---
+
+# DEC-NNN — TODO
+
+## Context
+
+## Decision
+
+## Consequences
+
+## Alternatives considered

--- a/docs/anti-patterns.md
+++ b/docs/anti-patterns.md
@@ -1,0 +1,17 @@
+---
+title: Anti-Patterns
+status: stub
+owner: TODO
+last-reviewed: TODO
+---
+
+# Anti-Patterns
+
+## Purpose
+
+Patterns to avoid in this codebase and why.
+
+## TODO
+
+- [ ] Fill in this document for the project.
+- [ ] Remove the `status: stub` marker once populated.

--- a/docs/api-contracts.md
+++ b/docs/api-contracts.md
@@ -1,0 +1,17 @@
+---
+title: API Contracts
+status: stub
+owner: TODO
+last-reviewed: TODO
+---
+
+# API Contracts
+
+## Purpose
+
+Public API surface: endpoints, request/response shapes, error contracts, versioning.
+
+## TODO
+
+- [ ] Fill in this document for the project.
+- [ ] Remove the `status: stub` marker once populated.

--- a/docs/app-spec.md
+++ b/docs/app-spec.md
@@ -1,0 +1,17 @@
+---
+title: Application Specification
+status: stub
+owner: TODO
+last-reviewed: TODO
+---
+
+# Application Specification
+
+## Purpose
+
+High-level description of what this application does, its scope, and primary capabilities.
+
+## TODO
+
+- [ ] Fill in this document for the project.
+- [ ] Remove the `status: stub` marker once populated.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,17 @@
+---
+title: Architecture
+status: stub
+owner: TODO
+last-reviewed: TODO
+---
+
+# Architecture
+
+## Purpose
+
+System architecture: components, boundaries, data flow, and major design decisions.
+
+## TODO
+
+- [ ] Fill in this document for the project.
+- [ ] Remove the `status: stub` marker once populated.

--- a/docs/brand-brief.md
+++ b/docs/brand-brief.md
@@ -1,0 +1,17 @@
+---
+title: Brand Brief
+status: stub
+owner: TODO
+last-reviewed: TODO
+---
+
+# Brand Brief
+
+## Purpose
+
+Brand positioning, tone, values, and visual identity guidelines.
+
+## TODO
+
+- [ ] Fill in this document for the project.
+- [ ] Remove the `status: stub` marker once populated.

--- a/docs/business-rules.md
+++ b/docs/business-rules.md
@@ -1,0 +1,17 @@
+---
+title: Business Rules
+status: stub
+owner: TODO
+last-reviewed: TODO
+---
+
+# Business Rules
+
+## Purpose
+
+Domain invariants and business rules the system must enforce.
+
+## TODO
+
+- [ ] Fill in this document for the project.
+- [ ] Remove the `status: stub` marker once populated.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,9 @@
+---
+title: Changelog (pointer)
+status: pointer
+---
+
+# Changelog
+
+The canonical changelog is the repo-root [`CHANGELOG.md`](../CHANGELOG.md),
+generated automatically via git-cliff. Do not edit by hand here.

--- a/docs/coding-standards.md
+++ b/docs/coding-standards.md
@@ -1,0 +1,17 @@
+---
+title: Coding Standards
+status: stub
+owner: TODO
+last-reviewed: TODO
+---
+
+# Coding Standards
+
+## Purpose
+
+Project coding standards. Defers to chrysa/shared-standards canon; record local deltas only.
+
+## TODO
+
+- [ ] Fill in this document for the project.
+- [ ] Remove the `status: stub` marker once populated.

--- a/docs/copywriting-guide.md
+++ b/docs/copywriting-guide.md
@@ -1,0 +1,17 @@
+---
+title: Copywriting Guide
+status: stub
+owner: TODO
+last-reviewed: TODO
+---
+
+# Copywriting Guide
+
+## Purpose
+
+Voice, tone, terminology, and microcopy conventions.
+
+## TODO
+
+- [ ] Fill in this document for the project.
+- [ ] Remove the `status: stub` marker once populated.

--- a/docs/data-dictionary.md
+++ b/docs/data-dictionary.md
@@ -1,0 +1,17 @@
+---
+title: Data Dictionary
+status: stub
+owner: TODO
+last-reviewed: TODO
+---
+
+# Data Dictionary
+
+## Purpose
+
+Canonical definitions of every entity, field, type, and constraint.
+
+## TODO
+
+- [ ] Fill in this document for the project.
+- [ ] Remove the `status: stub` marker once populated.

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -1,0 +1,13 @@
+---
+title: Decision Log
+status: stub
+---
+
+# Decision Log
+
+Chronological index of architecture decisions. Full records live in
+[`docs/adr/`](./adr/) (ADR-NNN) and the repo-root [`DECISIONS.md`](../DECISIONS.md).
+
+| Date | ID | Title | Status |
+|------|----|-------|--------|
+| TODO | ADR-001 | TODO | accepted |

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,17 @@
+---
+title: Deployment
+status: stub
+owner: TODO
+last-reviewed: TODO
+---
+
+# Deployment
+
+## Purpose
+
+Environments, deploy pipeline, rollback, and release procedure.
+
+## TODO
+
+- [ ] Fill in this document for the project.
+- [ ] Remove the `status: stub` marker once populated.

--- a/docs/domain-glossary.md
+++ b/docs/domain-glossary.md
@@ -1,0 +1,17 @@
+---
+title: Domain Glossary
+status: stub
+owner: TODO
+last-reviewed: TODO
+---
+
+# Domain Glossary
+
+## Purpose
+
+Ubiquitous-language glossary of domain terms (DDD).
+
+## TODO
+
+- [ ] Fill in this document for the project.
+- [ ] Remove the `status: stub` marker once populated.

--- a/docs/error-journal.md
+++ b/docs/error-journal.md
@@ -1,0 +1,17 @@
+---
+title: Error Journal
+status: stub
+owner: TODO
+last-reviewed: TODO
+---
+
+# Error Journal
+
+## Purpose
+
+Running log of notable errors encountered and their resolutions.
+
+## TODO
+
+- [ ] Fill in this document for the project.
+- [ ] Remove the `status: stub` marker once populated.

--- a/docs/feature-backlog.md
+++ b/docs/feature-backlog.md
@@ -1,0 +1,17 @@
+---
+title: Feature Backlog
+status: stub
+owner: TODO
+last-reviewed: TODO
+---
+
+# Feature Backlog
+
+## Purpose
+
+Lightweight backlog of candidate features (source of truth remains the tracker/Notion).
+
+## TODO
+
+- [ ] Fill in this document for the project.
+- [ ] Remove the `status: stub` marker once populated.

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -1,0 +1,17 @@
+---
+title: Integrations
+status: stub
+owner: TODO
+last-reviewed: TODO
+---
+
+# Integrations
+
+## Purpose
+
+Third-party services and internal systems this app integrates with, and how.
+
+## TODO
+
+- [ ] Fill in this document for the project.
+- [ ] Remove the `status: stub` marker once populated.

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -1,0 +1,17 @@
+---
+title: Known Issues
+status: stub
+owner: TODO
+last-reviewed: TODO
+---
+
+# Known Issues
+
+## Purpose
+
+Currently known bugs, limitations, and workarounds.
+
+## TODO
+
+- [ ] Fill in this document for the project.
+- [ ] Remove the `status: stub` marker once populated.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,17 @@
+---
+title: Observability
+status: stub
+owner: TODO
+last-reviewed: TODO
+---
+
+# Observability
+
+## Purpose
+
+Logging, metrics, tracing, alerting, and dashboards.
+
+## TODO
+
+- [ ] Fill in this document for the project.
+- [ ] Remove the `status: stub` marker once populated.

--- a/docs/personas.md
+++ b/docs/personas.md
@@ -1,0 +1,17 @@
+---
+title: Personas
+status: stub
+owner: TODO
+last-reviewed: TODO
+---
+
+# Personas
+
+## Purpose
+
+User personas: goals, contexts, pain points, and success criteria.
+
+## TODO
+
+- [ ] Fill in this document for the project.
+- [ ] Remove the `status: stub` marker once populated.

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,17 @@
+---
+title: Security
+status: stub
+owner: TODO
+last-reviewed: TODO
+---
+
+# Security
+
+## Purpose
+
+Threat model, authn/authz model, secrets handling, and security controls.
+
+## TODO
+
+- [ ] Fill in this document for the project.
+- [ ] Remove the `status: stub` marker once populated.

--- a/docs/system-patterns.md
+++ b/docs/system-patterns.md
@@ -1,0 +1,17 @@
+---
+title: System Patterns
+status: stub
+owner: TODO
+last-reviewed: TODO
+---
+
+# System Patterns
+
+## Purpose
+
+Recurring architectural and implementation patterns used across the codebase.
+
+## TODO
+
+- [ ] Fill in this document for the project.
+- [ ] Remove the `status: stub` marker once populated.

--- a/docs/ux-rules.md
+++ b/docs/ux-rules.md
@@ -1,0 +1,17 @@
+---
+title: UX Rules
+status: stub
+owner: TODO
+last-reviewed: TODO
+---
+
+# UX Rules
+
+## Purpose
+
+Interaction and usability rules that all UI work must follow.
+
+## TODO
+
+- [ ] Fill in this document for the project.
+- [ ] Remove the `status: stub` marker once populated.

--- a/examples/perfect_api_view.py
+++ b/examples/perfect_api_view.py
@@ -6,6 +6,8 @@ from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from perfect_serializer import PerfectSerializer
+
 
 class PerfectAPIView(APIView):
     def get(self, request, *args, **kwargs):

--- a/examples/perfect_api_view.py
+++ b/examples/perfect_api_view.py
@@ -1,0 +1,15 @@
+"""EXAMPLE — canonical pattern, copy & adapt.
+
+A thin DRF view: validate via serializer, delegate to a service.
+"""
+from rest_framework import status
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+
+class PerfectAPIView(APIView):
+    def get(self, request, *args, **kwargs):
+        serializer = PerfectSerializer(data=request.query_params)
+        serializer.is_valid(raise_exception=True)
+        # TODO: delegate to a service; no business logic inline.
+        return Response(serializer.validated_data, status=status.HTTP_200_OK)

--- a/examples/perfect_repository.py
+++ b/examples/perfect_repository.py
@@ -1,0 +1,11 @@
+"""EXAMPLE — canonical pattern, copy & adapt.
+
+A repository: the only place that touches the ORM/storage.
+"""
+from __future__ import annotations
+
+
+class UserRepository:
+    def find_by_id(self, user_id: str):
+        # TODO: real ORM query, e.g. User.objects.filter(pk=user_id).first()
+        raise NotImplementedError

--- a/examples/perfect_schema.py
+++ b/examples/perfect_schema.py
@@ -1,0 +1,16 @@
+"""EXAMPLE — canonical pattern, copy & adapt.
+
+A pydantic schema = typed data contract at a boundary.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel, EmailStr
+
+
+class User(BaseModel):
+    id: UUID
+    email: EmailStr
+    created_at: datetime

--- a/examples/perfect_serializer.py
+++ b/examples/perfect_serializer.py
@@ -1,0 +1,14 @@
+"""EXAMPLE — canonical pattern, copy & adapt.
+
+A DRF serializer = the validation/transport boundary.
+"""
+from rest_framework import serializers
+
+
+class PerfectSerializer(serializers.Serializer):
+    id = serializers.UUIDField()
+    email = serializers.EmailField()
+
+    def validate_email(self, value: str) -> str:
+        # TODO: domain-specific validation.
+        return value.lower()

--- a/examples/perfect_service.py
+++ b/examples/perfect_service.py
@@ -5,6 +5,10 @@ A service: pure business logic, framework-agnostic.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from perfect_repository import UserRepository
 
 
 class NotFoundError(Exception):
@@ -18,7 +22,7 @@ class User:
 
 
 class UserService:
-    def __init__(self, repo: "UserRepository") -> None:
+    def __init__(self, repo: UserRepository) -> None:
         self._repo = repo
 
     def get_user(self, user_id: str) -> User:

--- a/examples/perfect_service.py
+++ b/examples/perfect_service.py
@@ -1,0 +1,28 @@
+"""EXAMPLE — canonical pattern, copy & adapt.
+
+A service: pure business logic, framework-agnostic.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+class NotFoundError(Exception):
+    pass
+
+
+@dataclass(frozen=True)
+class User:
+    id: str
+    email: str
+
+
+class UserService:
+    def __init__(self, repo: "UserRepository") -> None:
+        self._repo = repo
+
+    def get_user(self, user_id: str) -> User:
+        user = self._repo.find_by_id(user_id)
+        if user is None:
+            raise NotFoundError(user_id)
+        return user

--- a/examples/perfect_viewset.py
+++ b/examples/perfect_viewset.py
@@ -1,0 +1,10 @@
+"""EXAMPLE — canonical pattern, copy & adapt.
+
+A DRF ViewSet wiring serializer + queryset; logic stays in services.
+"""
+from rest_framework import viewsets
+
+
+class PerfectViewSet(viewsets.ModelViewSet):
+    serializer_class = None  # TODO: PerfectSerializer
+    queryset = None          # TODO: Model.objects.all()

--- a/postmortems/_TEMPLATE.md
+++ b/postmortems/_TEMPLATE.md
@@ -1,0 +1,20 @@
+---
+title: TODO incident
+status: template
+date: TODO
+severity: TODO   # SEV1 | SEV2 | SEV3
+---
+
+# Postmortem — TODO
+
+## Summary
+
+## Impact
+
+## Timeline
+
+## Root cause
+
+## Resolution
+
+## Action items

--- a/postmortems/payment-incident-2026-05.md
+++ b/postmortems/payment-incident-2026-05.md
@@ -1,0 +1,20 @@
+---
+title: Payment incident (May 2026)
+status: example
+date: TODO
+severity: TODO
+---
+
+# Postmortem — Payment incident (May 2026)
+
+> **EXAMPLE** — illustrative stub. Replace with a real postmortem or delete.
+
+## Summary
+
+## Impact
+
+## Timeline
+
+## Root cause
+
+## Action items

--- a/postmortems/webhook-failure-2026-06.md
+++ b/postmortems/webhook-failure-2026-06.md
@@ -1,0 +1,20 @@
+---
+title: Webhook failure (June 2026)
+status: example
+date: TODO
+severity: TODO
+---
+
+# Postmortem — Webhook failure (June 2026)
+
+> **EXAMPLE** — illustrative stub. Replace with a real postmortem or delete.
+
+## Summary
+
+## Impact
+
+## Timeline
+
+## Root cause
+
+## Action items

--- a/prompts/classification-agent.md
+++ b/prompts/classification-agent.md
@@ -1,0 +1,17 @@
+---
+title: Classification Agent Prompt
+status: stub
+owner: TODO
+last-reviewed: TODO
+---
+
+# Classification Agent Prompt
+
+## Purpose
+
+System prompt + label set for the classification agent.
+
+## TODO
+
+- [ ] Fill in this document for the project.
+- [ ] Remove the `status: stub` marker once populated.

--- a/prompts/extraction-agent.md
+++ b/prompts/extraction-agent.md
@@ -1,0 +1,17 @@
+---
+title: Extraction Agent Prompt
+status: stub
+owner: TODO
+last-reviewed: TODO
+---
+
+# Extraction Agent Prompt
+
+## Purpose
+
+System prompt + schema for the structured-extraction agent.
+
+## TODO
+
+- [ ] Fill in this document for the project.
+- [ ] Remove the `status: stub` marker once populated.

--- a/prompts/onboarding-agent.md
+++ b/prompts/onboarding-agent.md
@@ -1,0 +1,17 @@
+---
+title: Onboarding Agent Prompt
+status: stub
+owner: TODO
+last-reviewed: TODO
+---
+
+# Onboarding Agent Prompt
+
+## Purpose
+
+System prompt + behavior spec for the onboarding agent.
+
+## TODO
+
+- [ ] Fill in this document for the project.
+- [ ] Remove the `status: stub` marker once populated.

--- a/prompts/sales-agent.md
+++ b/prompts/sales-agent.md
@@ -1,0 +1,17 @@
+---
+title: Sales Agent Prompt
+status: stub
+owner: TODO
+last-reviewed: TODO
+---
+
+# Sales Agent Prompt
+
+## Purpose
+
+System prompt + behavior spec for the sales agent.
+
+## TODO
+
+- [ ] Fill in this document for the project.
+- [ ] Remove the `status: stub` marker once populated.

--- a/prompts/support-agent.md
+++ b/prompts/support-agent.md
@@ -1,0 +1,17 @@
+---
+title: Support Agent Prompt
+status: stub
+owner: TODO
+last-reviewed: TODO
+---
+
+# Support Agent Prompt
+
+## Purpose
+
+System prompt + behavior spec for the support agent.
+
+## TODO
+
+- [ ] Fill in this document for the project.
+- [ ] Remove the `status: stub` marker once populated.

--- a/schemas/payment.schema.json
+++ b/schemas/payment.schema.json
@@ -1,0 +1,17 @@
+{
+  "$id": "https://chrysa.dev/schemas/payment.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": true,
+  "description": "STUB — define the real schema.",
+  "properties": {
+    "id": {
+      "description": "Unique identifier (TODO)",
+      "type": "string"
+    }
+  },
+  "required": [
+    "id"
+  ],
+  "title": "Payment",
+  "type": "object"
+}

--- a/schemas/project.schema.json
+++ b/schemas/project.schema.json
@@ -1,0 +1,17 @@
+{
+  "$id": "https://chrysa.dev/schemas/project.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": true,
+  "description": "STUB — define the real schema.",
+  "properties": {
+    "id": {
+      "description": "Unique identifier (TODO)",
+      "type": "string"
+    }
+  },
+  "required": [
+    "id"
+  ],
+  "title": "Project",
+  "type": "object"
+}

--- a/schemas/user.schema.json
+++ b/schemas/user.schema.json
@@ -1,0 +1,17 @@
+{
+  "$id": "https://chrysa.dev/schemas/user.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": true,
+  "description": "STUB — define the real schema.",
+  "properties": {
+    "id": {
+      "description": "Unique identifier (TODO)",
+      "type": "string"
+    }
+  },
+  "required": [
+    "id"
+  ],
+  "title": "User",
+  "type": "object"
+}

--- a/tests/e2e-scenarios.md
+++ b/tests/e2e-scenarios.md
@@ -1,0 +1,17 @@
+---
+title: E2E Scenarios
+status: stub
+owner: TODO
+last-reviewed: TODO
+---
+
+# E2E Scenarios
+
+## Purpose
+
+End-to-end user scenarios covered (or to cover) by E2E tests.
+
+## TODO
+
+- [ ] Fill in this document for the project.
+- [ ] Remove the `status: stub` marker once populated.

--- a/tests/edge-cases.md
+++ b/tests/edge-cases.md
@@ -1,0 +1,17 @@
+---
+title: Edge Cases
+status: stub
+owner: TODO
+last-reviewed: TODO
+---
+
+# Edge Cases
+
+## Purpose
+
+Catalogue of edge cases the system must handle, with expected behavior.
+
+## TODO
+
+- [ ] Fill in this document for the project.
+- [ ] Remove the `status: stub` marker once populated.

--- a/tests/regression-tests.md
+++ b/tests/regression-tests.md
@@ -1,0 +1,17 @@
+---
+title: Regression Tests
+status: stub
+owner: TODO
+last-reviewed: TODO
+---
+
+# Regression Tests
+
+## Purpose
+
+Index of regression scenarios tied to past incidents/bugs.
+
+## TODO
+
+- [ ] Fill in this document for the project.
+- [ ] Remove the `status: stub` marker once populated.

--- a/workflows/auth-flow.md
+++ b/workflows/auth-flow.md
@@ -1,0 +1,17 @@
+---
+title: Auth Flow
+status: stub
+owner: TODO
+last-reviewed: TODO
+---
+
+# Auth Flow
+
+## Purpose
+
+End-to-end authentication flow: actors, steps, states, and edge cases.
+
+## TODO
+
+- [ ] Fill in this document for the project.
+- [ ] Remove the `status: stub` marker once populated.

--- a/workflows/billing-flow.md
+++ b/workflows/billing-flow.md
@@ -1,0 +1,17 @@
+---
+title: Billing Flow
+status: stub
+owner: TODO
+last-reviewed: TODO
+---
+
+# Billing Flow
+
+## Purpose
+
+End-to-end billing flow: plans, checkout, invoices, dunning.
+
+## TODO
+
+- [ ] Fill in this document for the project.
+- [ ] Remove the `status: stub` marker once populated.

--- a/workflows/notification-flow.md
+++ b/workflows/notification-flow.md
@@ -1,0 +1,17 @@
+---
+title: Notification Flow
+status: stub
+owner: TODO
+last-reviewed: TODO
+---
+
+# Notification Flow
+
+## Purpose
+
+End-to-end notification flow: triggers, channels, preferences, delivery.
+
+## TODO
+
+- [ ] Fill in this document for the project.
+- [ ] Remove the `status: stub` marker once populated.

--- a/workflows/onboarding-flow.md
+++ b/workflows/onboarding-flow.md
@@ -1,0 +1,17 @@
+---
+title: Onboarding Flow
+status: stub
+owner: TODO
+last-reviewed: TODO
+---
+
+# Onboarding Flow
+
+## Purpose
+
+End-to-end onboarding flow from signup to activation.
+
+## TODO
+
+- [ ] Fill in this document for the project.
+- [ ] Remove the `status: stub` marker once populated.


### PR DESCRIPTION
## What
Backfill the chrysa standardized documentation structure (chrysa/shared-standards#82) into project-init.

## Tree (python examples)
`docs/ ai/ prompts/ schemas/ workflows/ decisions/ postmortems/ tests/ examples/` — stubs marked `status: stub`.

## Reconciliation
Additions only — existing `docs/adr/`, `DECISIONS.md`, root canon untouched. `docs/decision-log.md` indexes `docs/adr/`; `docs/changelog.md` & `ai/CLAUDE.md` are pointers. README gains a Documentation map section.

## Incidental
One chore commit normalizes a pre-existing double trailing newline in `.github/dependabot.yml` (surfaced by the all-files lint gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)