### PR TITLE
chore(ci): pre-push test/sonar hooks and dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -92,4 +92,3 @@ updates:
                   - flake8*
       cooldown:
           default-days: 7
-

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,47 +1,63 @@
----
 default_language_version:
-    python: python3
+  python: python3
 fail_fast: false
 minimum_pre_commit_version: 4.1.0
 repos:
-    - repo: https://github.com/pre-commit/pre-commit-hooks
-      rev: v6.0.0
-      hooks:
-          - id: check-json
-          - id: check-yaml
-            args: [--allow-multiple-documents]
-            exclude: ^(\.github/)ISSUE_TEMPLATE/
-          - id: trailing-whitespace
-          - id: end-of-file-fixer
-          - id: detect-private-key
-          - id: no-commit-to-branch
-            args: [--branch, main]
-    - repo: https://github.com/igorshubovych/markdownlint-cli
-      rev: v0.48.0
-      hooks:
-          - id: markdownlint
-            args: [--fix]
-            stages: [manual]
-    - repo: https://github.com/chrysa/pre-commit-tools
-      rev: v0.1.1-92
-      hooks:
-          - id: yaml-sorter
-            exclude: ^(\.github/|GitVersion\.yml)
-          - id: json-sorter
-          - id: env-file-check
-          - id: adr-gate
-          - id: python-print-detection
-          - id: python-pprint-detection
-          - id: no-bare-except
-          - id: python-logger-detection
-          - id: no-sync-in-async
-          - id: debugger-detection
-          - id: regression-gate
-            stages: [pre-push]
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v6.0.0
+  hooks:
+  - id: check-json
+  - id: check-yaml
+    args: [--allow-multiple-documents]
+    exclude: ^(\.github/)ISSUE_TEMPLATE/
+  - id: trailing-whitespace
+  - id: end-of-file-fixer
+  - id: detect-private-key
+  - id: no-commit-to-branch
+    args: [--branch, main]
+- repo: https://github.com/igorshubovych/markdownlint-cli
+  rev: v0.48.0
+  hooks:
+  - id: markdownlint
+    args: [--fix]
+    stages: [manual]
+- repo: https://github.com/chrysa/pre-commit-tools
+  rev: v0.1.1-92
+  hooks:
+  - id: yaml-sorter
+    exclude: ^(\.github/|GitVersion\.yml)
+  - id: json-sorter
+  - id: env-file-check
+  - id: adr-gate
+  - id: python-print-detection
+  - id: python-pprint-detection
+  - id: no-bare-except
+  - id: python-logger-detection
+  - id: no-sync-in-async
+  - id: debugger-detection
+  - id: regression-gate
+    stages: [pre-push]
 
-    - repo: https://github.com/compilerla/conventional-pre-commit
-      rev: v4.4.0
-      hooks:
-          - id: conventional-pre-commit
-            stages: [commit-msg]
-            args: [feat, fix, docs, style, refactor, test, chore, perf, revert, ci]
+- repo: https://github.com/compilerla/conventional-pre-commit
+  rev: v4.4.0
+  hooks:
+  - id: conventional-pre-commit
+    stages: [commit-msg]
+    args: [feat, fix, docs, style, refactor, test, chore, perf, revert, ci]
+- repo: local
+  hooks:
+  - id: run-tests
+    name: run test suite (with coverage)
+    entry: make docker-test
+    language: system
+    pass_filenames: false
+    stages:
+    - pre-push
+  - id: sonar-scanner
+    name: sonar cloud analysis
+    entry: bash -c 'docker run --rm --env SONAR_TOKEN -v "$(pwd):/usr/src" sonarsource/sonar-scanner-cli:11 
+      -Dsonar.host.url=https://sonarcloud.io -Dsonar.organization=chrysa -Dsonar.projectKey=chrysa_project-init'
+    language: system
+    pass_filenames: false
+    stages:
+    - pre-push

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,7 +55,7 @@ repos:
     - pre-push
   - id: sonar-scanner
     name: sonar cloud analysis
-    entry: bash -c 'docker run --rm --env SONAR_TOKEN -v "$(pwd):/usr/src" sonarsource/sonar-scanner-cli:11 
+    entry: bash -c 'docker run --rm --env SONAR_TOKEN -v "$(pwd):/usr/src" sonarsource/sonar-scanner-cli:11
       -Dsonar.host.url=https://sonarcloud.io -Dsonar.organization=chrysa -Dsonar.projectKey=chrysa_project-init'
     language: system
     pass_filenames: false


### PR DESCRIPTION
## Summary
CI/tooling chore for project-init.

- Add `run-tests` + `sonar-scanner` hooks at the **pre-push** stage
- Update `dependabot.yml`, pre-commit and Claude settings

## Notes
Behind `main` by a few CI commits; PR diff is the 2 real commits only.
