### PR TITLE
chore: adopt chrysa standards (makefile-tier + lean CI)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,41 +1,33 @@
 ---
+# Thin caller of the generalized chrysa lean CI (compose-backed app).
+# Gate = pre-commit; reports -> Sonar; tests via make docker-test; sonar.
+# Auto-versioning stays in release.yml (GitVersion).
+
 name: CI
 
 on:
-  push:
-    branches:
-      - main
-      - develop
-      - "feat/**"
-      - "fix/**"
-      - "ci/**"
-      - "chore/**"
-  pull_request:
-    branches: [main, develop]
-  workflow_dispatch:
+    pull_request:
+        branches: [main]
+    push:
+        branches: [main, "feat/**", "fix/**", "chore/**", "ci/**"]
+    workflow_dispatch:
 
 permissions:
-  contents: read
+    contents: read
+    checks: write
+    pull-requests: write
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+    group: ci-${{ github.ref }}
+    cancel-in-progress: true
 
 jobs:
-  lint:
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    name: Lint & validate
-
-    steps:
-      - uses: actions/checkout@v6.0.3
-
-      - uses: chrysa/github-actions/python-setup@v1.1.3
+    ci:
+        uses: chrysa/github-actions/.github/workflows/ci-python-app.yml@main
         with:
-          python-version: "3.14"
-          cache: pip
-
-      - name: Run pre-commit hooks
-        uses: pre-commit/action@v3.0.1
-        env:
-          SKIP: no-commit-to-branch
+            sources: "."
+            typecheck-paths: scripts
+            project-key: chrysa_project-init
+            project-name: project-init
+            sonar-sources: "."
+        secrets: inherit


### PR DESCRIPTION
Adds the `# makefile-tier: lib` marker (EXECUTION_STANDARD §1.1) and a thin caller of the reusable lean CI where applicable. Auto-versioning unchanged.