### PR TITLE
ci: pin chrysa/github-actions reusable workflows to @v1.2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ concurrency:
 
 jobs:
     ci:
-        uses: chrysa/github-actions/.github/workflows/ci-python-app.yml@main
+        uses: chrysa/github-actions/.github/workflows/ci-python-app.yml@v1.2.0
         with:
             sources: "."
             typecheck-paths: scripts

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -11,4 +11,4 @@ concurrency:
 
 jobs:
     call:
-        uses: chrysa/github-actions/.github/workflows/dependabot-auto-merge.yml@main
+        uses: chrysa/github-actions/.github/workflows/dependabot-auto-merge.yml@v1.2.0

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -7,4 +7,4 @@ on:
 
 jobs:
     call:
-        uses: chrysa/github-actions/.github/workflows/dependencies.yml@main
+        uses: chrysa/github-actions/.github/workflows/dependencies.yml@v1.2.0

--- a/.github/workflows/enforce-feature-branch.yml
+++ b/.github/workflows/enforce-feature-branch.yml
@@ -7,4 +7,4 @@ on:
 
 jobs:
     call:
-        uses: chrysa/github-actions/.github/workflows/enforce-feature-branch.yml@main
+        uses: chrysa/github-actions/.github/workflows/enforce-feature-branch.yml@v1.2.0

--- a/.github/workflows/quality-gate-check.yml
+++ b/.github/workflows/quality-gate-check.yml
@@ -19,4 +19,4 @@ permissions:
 
 jobs:
     call:
-        uses: chrysa/github-actions/.github/workflows/quality-gate-check.yml@main
+        uses: chrysa/github-actions/.github/workflows/quality-gate-check.yml@v1.2.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,6 @@ on:
 
 jobs:
     call:
-        uses: chrysa/github-actions/.github/workflows/release.yml@main
+        uses: chrysa/github-actions/.github/workflows/release.yml@v1.2.0
         secrets:
           RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -13,4 +13,4 @@ permissions:
 
 jobs:
     call:
-        uses: chrysa/github-actions/.github/workflows/secret-scan.yml@main
+        uses: chrysa/github-actions/.github/workflows/secret-scan.yml@v1.2.0


### PR DESCRIPTION
Pins all `chrysa/github-actions/.github/workflows/*.yml` references from `@main` to release tag `@v1.2.0` (verified to expose every referenced workflow). Addresses the **Pin GitHub Actions** item of the Standards compliance backlog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)