### PR TITLE
fix(docker-test): chown /app so coverage can write (unblocks Sonar)

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -8,7 +8,7 @@ FROM deps AS test
 COPY scripts/ ./scripts/
 COPY tests/ ./tests/
 # Run as non-root user
-RUN useradd --create-home appuser
+RUN useradd --create-home appuser && chown -R appuser:appuser /app
 USER appuser
 ENV PYTHONPATH=/app/scripts
 CMD ["pytest", "tests/", "--cov=scripts", "--cov-branch", \


### PR DESCRIPTION
Non-root `appuser` couldn't write coverage data to root-owned `/app` -> `coverage.DataError: unable to open database file` (tests passed, coverage crashed, exit 3). Sonar job is `needs: test` so it was skipped. Fix: chown /app to appuser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)