### PR TITLE
chore: adopt canonical GitVersion.yml (ContinuousDeployment)

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -20,7 +20,7 @@ branches:
     regex: ^main$
     tag: ''
 increment: Inherit
-major-version-bump-message: '^(feat|fix|refactor)(\(.+\))?!:.+'
-minor-version-bump-message: '^feat(\(.+\))?:.+'
+major-version-bump-message: ^(feat|fix|refactor)(\(.+\))?!:.+
+minor-version-bump-message: ^feat(\(.+\))?:.+
 mode: ContinuousDeployment
-patch-version-bump-message: '^(fix|refactor|perf|docs|chore)(\(.+\))?:.+'
+patch-version-bump-message: ^(fix|refactor|perf|docs|chore)(\(.+\))?:.+


### PR DESCRIPTION
Align GitVersion with canonical chrysa ContinuousDeployment config. Cosmetic-drift tail of the release-config fan-out. Refs chrysa/shared-standards#127