### PR TITLE
chore: sync chrysa shared standards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,6 @@ jobs:
                   project-key: chrysa_target
                   organization: chrysa
                   project-name: target
-                  sources: .
+                  sources: target
                   tests: tests
                   coverage-report: coverage.xml


### PR DESCRIPTION
Automated distribution of chrysa shared standards.

**Source:** `chrysa/shared-standards@8eb3cd1d527e1218f4a12596a90253deec7ae72c`
Managed files (transverse `CLAUDE.md` import, `.chrysa/STANDARDS.md`,
shared skills/agents/commands, CI workflows, lint/quality, pre-commit)
were refreshed by `scripts/distribute-standards.sh`.

Review the diff: repo-specific content is preserved; only managed,
delimited blocks and shared files are updated.

Refs: chrysa/shared-standards