### PR TITLE
fix(ci): correct Sonar project key + bump scanner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,9 +74,9 @@ jobs:
                   python-version: "3.14"
                   sonar-token: ${{ secrets.SONAR_TOKEN }}
                   github-token: ${{ secrets.GITHUB_TOKEN }}
-                  project-key: chrysa_target
+                  project-key: chrysa_project-init
                   organization: chrysa
-                  project-name: target
-                  sources: .
+                  project-name: project-init
+                  sources: scripts
                   tests: tests
                   coverage-report: coverage.xml


### PR DESCRIPTION
Sonar used placeholder `chrysa_target` + `sonar-scan-python@v1.0.12` (no disjoint source/test logic) -> tests indexed twice (exit 3). Fix: key `chrysa_project-init` + bump `@v1.1.3`.

Generated with Claude Code