### PR TITLE
chore: sync chrysa shared standards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,11 +3,11 @@
 #
 # Usage: copy to .github/workflows/ci.yml. The applier
 # (scripts/apply-repo-standard.sh) substitutes the ${...} placeholders:
-#   target      import package / source dir       (e.g. django_pytest)
-#   target tests      ruff sources, space-separated     (e.g. "django_pytest tests")
+#   project_init      import package / source dir       (e.g. django_pytest)
+#   project_init tests      ruff sources, space-separated     (e.g. "django_pytest tests")
 #   tests        test dir                          (e.g. tests)
-#   target    repo name                         (e.g. django-pytest)
-#   chrysa_target  SonarCloud project key            (e.g. chrysa_django-pytest)
+#   project-init    repo name                         (e.g. django-pytest)
+#   chrysa_project-init  SonarCloud project key            (e.g. chrysa_django-pytest)
 #
 # ⚠️ This file lives in workflows/ (NOT .github/workflows/) — it is a copy-to-use
 #    template, not a reusable `uses:` workflow.
@@ -77,6 +77,6 @@ jobs:
                   project-key: chrysa_project-init
                   organization: chrysa
                   project-name: project-init
-                  sources: scripts
+                  sources: project_init
                   tests: tests
                   coverage-report: coverage.xml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to target
+# Contributing to project-init
 
 Thanks for contributing. This repo follows the chrysa
 [Execution Standard](https://github.com/chrysa/shared-standards/blob/main/EXECUTION_STANDARD.md).


### PR DESCRIPTION
Automated distribution of chrysa shared standards.

**Source:** `chrysa/shared-standards@94dd8101537b2661a2a9d8eb262b94462220c38d`
Managed files (transverse `CLAUDE.md` import, `.chrysa/STANDARDS.md`,
shared skills/agents/commands, CI workflows, lint/quality, pre-commit)
were refreshed by `scripts/distribute-standards.sh`.

Review the diff: repo-specific content is preserved; only managed,
delimited blocks and shared files are updated.

Refs: chrysa/shared-standards