### PR TITLE
chore: sync chrysa shared standards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,18 @@ jobs:
             - name: Run tests via Docker
               run: make docker-test
 
+            # Coverage is generated inside the test job; the sonar job runs on a
+            # separate runner, so the report must travel as an artifact. The name
+            # MUST be test-results-<python-version> — that is exactly what
+            # sonar-scan-python downloads into reports/.
+            - name: Upload coverage report
+              if: always()
+              uses: actions/upload-artifact@v7
+              with:
+                  name: test-results-3.14
+                  path: coverage.xml
+                  if-no-files-found: warn
+
     sonar:
         name: SonarCloud
         if: ${{ github.actor != 'dependabot[bot]' }}
@@ -79,4 +91,6 @@ jobs:
                   project-name: project-init
                   sources: project_init
                   tests: tests
-                  coverage-report: coverage.xml
+                  # Downloaded from the test-results-3.14 artifact into reports/
+                  # by the action; matches sonar-scan-python's default path.
+                  coverage-report: reports/coverage.xml


### PR DESCRIPTION
Automated distribution of chrysa shared standards.

**Source:** `chrysa/shared-standards@eec88ecd69649827bc50bad542ad007483f26ec9`
Managed files (transverse `CLAUDE.md` import, `.chrysa/STANDARDS.md`,
shared skills/agents/commands, CI workflows, lint/quality, pre-commit)
were refreshed by `scripts/distribute-standards.sh`.

Review the diff: repo-specific content is preserved; only managed,
delimited blocks and shared files are updated.

Refs: chrysa/shared-standards