### PR TITLE
chore: sync chrysa shared standards

### DIFF
--- a/.claude/skills/testing-pytest/SKILL.md
+++ b/.claude/skills/testing-pytest/SKILL.md
@@ -39,6 +39,40 @@ async def test_something(mocker: MockerFixture):
     mock_service.assert_awaited_once()
 ```
 
+### Assertions
+Every `assert` carries a message in f-string debug format (`{var=}`) — it names what was expected and what was received. Bare `assert x == y` is forbidden.
+```python
+assert count == 5, f"expected 5 items, got {count=}"
+assert user.is_active, f"user should be active: {user.id=} {user.is_active=}"
+```
+
+### Fixtures — parametrizable factories
+A fixture returns a `_load(**kwargs)` callable with faker/factory defaults, so a test overrides only what it cares about. House convention: function named `fixt_<name>`, exposed as `name="<name>"`.
+```python
+@pytest.fixture(name="user_data")
+def fixt_user_data(faker):
+    def _load(**kwargs):
+        return {"email": kwargs.get("email", faker.email())}
+    return _load
+```
+`scope="function"` by default; widen (`module` / `session`) only for immutable, expensive-to-build data. Never a static fixture with hardcoded values.
+
+### Parametrize, never loop
+A loop hides failures — once one case fails the later ones never run — and loses per-case isolation. Use `@pytest.mark.parametrize`:
+```python
+@pytest.mark.parametrize("value", [1, 2, 3])
+def test_positive(value):
+    assert process(value) > 0, f"{value=}"
+```
+
+### Structure & isolation
+- Group related cases as **nested classes** under one class per unit (`class TestMqtt: class TestConnection: ...`) — not many module-level classes for the same unit.
+- **Unit tests mock the DB and all external I/O** (no DB marker). **Integration tests** are marked explicitly (`@pytest.mark.integration`, plus `@pytest.mark.django_db` on Django) and hit the real DB.
+- **No type annotations** in test files — they read as executable specs.
+
+### Coverage — cover every path
+Target 100% branch coverage on business logic and services: every `if/elif/else`, every error/exception path, every fallback and default. Assert side effects too (DB writes, emitted logs), not only return values.
+
 ### Status codes
 ```python
 from fastapi import status
@@ -62,3 +96,7 @@ tests/
 - Hardcoded route strings (`"/api/v1/completions"` inline)
 - Integer status codes (use `status.HTTP_*` or `HTTPStatus.*`)
 - `from unittest.mock import patch` — use `mocker.patch` instead
+- Bare `assert` without a descriptive message
+- Loops over test cases (use `@pytest.mark.parametrize`)
+- Static fixtures with hardcoded values (use the `_load(**kwargs)` factory pattern)
+- Type annotations in test files


### PR DESCRIPTION
Automated distribution of chrysa shared standards.

**Source:** `chrysa/shared-standards@c96e8d1f5c8c01a5759a8592f83123a07faeab93`
Managed files (inline transverse standards block in `CLAUDE.md`,
shared skills/agents/commands, CI workflows, lint/quality, pre-commit)
were refreshed by `scripts/distribute-standards.sh`.

Review the diff: repo-specific content is preserved; only managed,
delimited blocks and shared files are updated.

Refs: chrysa/shared-standards