### PR TITLE
chore: sync chrysa shared standards

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
     stages:
     - manual
 - repo: https://github.com/chrysa/pre-commit-tools
-  rev: v0.1.1-100
+  rev: v0.2.0-247
   hooks:
   - id: makefile-check
   - id: yaml-sorter
@@ -53,6 +53,10 @@ repos:
   - id: claude-mcp-config
   - id: python-no-unittest-import
   - id: claude-assets-present
+  - id: python-untyped-raise
+    exclude: ^tests?/
+  - id: python-mutable-default
+  - id: python-dispatch-ladder
 - repo: https://github.com/compilerla/conventional-pre-commit
   rev: v4.4.0
   hooks:


### PR DESCRIPTION
Automated distribution of chrysa shared standards.

**Source:** `chrysa/shared-standards@07ef95067e26fb3ad1f693a52ee5eacd30dd819c`
Managed files (inline transverse standards block in `CLAUDE.md`,
shared skills/agents/commands, CI workflows, lint/quality, pre-commit)
were refreshed by `scripts/distribute-standards.sh`.

Review the diff: repo-specific content is preserved; only managed,
delimited blocks and shared files are updated.

Refs: chrysa/shared-standards