### PR TITLE
chore(hooks): drop the docker-based sonar-scanner pre-push hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -83,14 +83,6 @@ repos:
     pass_filenames: false
     stages:
     - pre-push
-  - id: sonar-scanner
-    name: sonar cloud analysis
-    entry: bash -c 'docker run --rm --env SONAR_TOKEN -v "$(pwd):/usr/src" sonarsource/sonar-scanner-cli:11
-      -Dsonar.host.url=https://sonarcloud.io -Dsonar.organization=chrysa -Dsonar.projectKey=chrysa_project-init'
-    language: system
-    pass_filenames: false
-    stages:
-    - pre-push
 - repo: https://github.com/gitleaks/gitleaks
   rev: v8.30.1
   hooks:


### PR DESCRIPTION
The `sonar-scanner` local hook shells out to `docker run sonarsource/sonar-scanner-cli`
at push time. Two rules in the shared standards forbid that:

- **hooks are host-native** — the commit/push gate must work with only `pre-commit`
  installed, never depending on the Docker daemon being up;
- **container-side enforcement is CI's job** — SonarCloud already runs in `sonar.yml`,
  and the global pre-push hook queries the quality gate.

The hook is byte-identical in 9 fleet repos (hand-copied, never centralised), so it is
removed rather than migrated. No coverage is lost: the scan still runs in CI.
