### PR TITLE
fix(quality-gate): anchor coverage parsing on summary lines

### DIFF
--- a/scripts/quality_gate.py
+++ b/scripts/quality_gate.py
@@ -86,14 +86,41 @@ class QualityGate:
                 return int(match.group(1))
         return 0
 
+    COVERAGE_PATTERNS = (
+        r"^TOTAL\s+.*?(\d+(?:\.\d+)?)%",  # pytest-cov / coverage term report
+        r"Total coverage:\s*(\d+(?:\.\d+)?)%",  # --cov-fail-under summary line
+        r"All files\s*\|\s*(\d+(?:\.\d+)?)",  # jest / istanbul text summary
+        r"^Statements\s*:\s*(\d+(?:\.\d+)?)%",  # nyc text-summary
+    )
+
     def _parse_coverage(self, output: str) -> float:
-        for line in output.splitlines():
-            if any(token in line.lower() for token in ["total", "coverage", "covered"]):
-                for value in re.findall(r"(\d+(?:\.\d+)?)%", line):
-                    try:
-                        return float(value)
-                    except ValueError:
-                        continue
+        for pattern in self.COVERAGE_PATTERNS:
+            match = re.search(pattern, output, flags=re.IGNORECASE | re.MULTILINE)
+            if match:
+                try:
+                    return float(match.group(1))
+                except ValueError:
+                    continue
+        return self._parse_coverage_report()
+
+    def _parse_coverage_report(self) -> float:
+        """Read the coverage percentage from a written XML report.
+
+        `make test-cov` may emit only `--cov-report=xml`, in which case stdout
+        carries no summary at all and the textual patterns above find nothing.
+        """
+        for candidate in (Path("reports/coverage.xml"), Path("coverage.xml")):
+            if not candidate.is_file():
+                continue
+            match = re.search(
+                r'<coverage[^>]*\bline-rate="([0-9.]+)"',
+                candidate.read_text(encoding="utf-8", errors="replace"),
+            )
+            if match:
+                try:
+                    return round(float(match.group(1)) * 100, 2)
+                except ValueError:
+                    continue
         return -1.0
 
     def _parse_warning_count(self, output: str) -> int:


### PR DESCRIPTION
Ports the anchored coverage parser into this repo's vendored `scripts/quality_gate.py`.

## The defect
`_parse_coverage` scanned every line containing `total`/`coverage`/`covered` and returned the first `N%` it found. With `-v` in `addopts` — the fleet default — pytest prints one line per test with a progress marker:

```
tests/test_thing.py::test_value_is_covered PASSED   [ 13%]
```

so the gate reported **13.0** for a suite sitting at 94%. Observed for real on pre-commit-tools: 13.0 against a 58.0 baseline.

## The fix
Anchored patterns (`^TOTAL … %`, `Total coverage: X%`, istanbul `All files |`, nyc `Statements :`), then a fallback to the `line-rate` of a written `coverage.xml` for the `--cov-report=xml`-only case.

Identical to the canonical implementation in chrysa/shared-standards (#259) and to chrysa/chrysa-lib#218.

## Why this arrives as one PR of many
The same defect has now had to be fixed by hand in **16 repos**, because `quality_gate.py` is vendored rather than distributed — chrysa/shared-standards#274. Behaviour verified on the patched file: `[ 13%]` progress marker → 94.0, `Total coverage: 87.5%` → 87.5, XML fallback → 94.12.