### PR TITLE
ci: run CI on develop, the branch every feature PR targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ name: CI
 
 on:
     pull_request:
-        branches: [main]
+        branches: [develop, main]
     push:
         branches:
             - main
@@ -32,6 +32,7 @@ on:
             - "fix/**"
             - "chore/**"
             - "ci/**"
+            - develop
     workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
`pull_request` was gated on `[main]` only. Since the branch model made `develop` the default branch and the integration target, a feature PR into `develop` matched no trigger and **CI never ran on it** — the absent red/green reads as "nothing to report".

Adds `develop` to the trigger lists. Swept from `chrysa/shared-standards` (`scripts/ci_develop_trigger.py`).