### PR TITLE
ci: concurrency group and job timeouts (annexe CI-030, CI-031)

### DIFF
--- a/.github/workflows/action-check.yml
+++ b/.github/workflows/action-check.yml
@@ -10,10 +10,15 @@
     - master
     paths:
     - .github/workflows/**
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
 jobs:
   actionlint:
     name: Lint workflows
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
     - name: Checkout
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1

--- a/.github/workflows/approved-label.yml
+++ b/.github/workflows/approved-label.yml
@@ -6,6 +6,7 @@ jobs:
   label-when-approved:
     name: Label when approved
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
     - name: Label when approved by committers
       uses: TobKed/label-when-approved-action@0058d0094da27e116fad6e0da516ebe1107f26de

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -4,9 +4,14 @@
     - opened
     - ready_for_review
     - reopened
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
 jobs:
   add-reviews:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
     - name: Checkout
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1

--- a/.github/workflows/auto-update-pre-commit.yml
+++ b/.github/workflows/auto-update-pre-commit.yml
@@ -6,6 +6,7 @@ jobs:
   pre-commit-autoupdate:
     name: Bump pre-commit hooks
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
     - name: Checkout
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -5,6 +5,10 @@ on:
     pull_request_target:
         types: [closed, edited, opened, reopened]
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
 jobs:
     call:
         uses: chrysa/github-actions/.github/workflows/dependencies.yml@v1.6.0

--- a/.github/workflows/enforce-feature-branch.yml
+++ b/.github/workflows/enforce-feature-branch.yml
@@ -5,6 +5,10 @@ on:
     pull_request:
         types: [opened, synchronize, reopened, ready_for_review]
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
 jobs:
     call:
         uses: chrysa/github-actions/.github/workflows/enforce-feature-branch.yml@v1.6.0

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -2,10 +2,15 @@
   pull_request: null
   workflow_call: null
   workflow_dispatch: null
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
 jobs:
   labels:
     name: Apply labels on pull request
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
     - name: Get Code
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1

--- a/.github/workflows/pr-dependencies.yml
+++ b/.github/workflows/pr-dependencies.yml
@@ -14,10 +14,15 @@
   - cron: 0 0 * * *
   workflow_call: null
   workflow_dispatch: null
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
 jobs:
   check_dependencies:
     name: Check Dependencies
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
     - env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pull-request-size.yml
+++ b/.github/workflows/pull-request-size.yml
@@ -2,6 +2,7 @@
 jobs:
   size-label:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
     - env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/quality-gate-check.yml
+++ b/.github/workflows/quality-gate-check.yml
@@ -17,6 +17,10 @@ permissions:
     contents: read
     statuses: write
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
 jobs:
     call:
         uses: chrysa/github-actions/.github/workflows/quality-gate-check.yml@v1.6.0

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -11,6 +11,10 @@ permissions:
     contents: read
     pull-requests: read
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
 jobs:
     call:
         uses: chrysa/github-actions/.github/workflows/secret-scan.yml@v1.6.0

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -13,6 +13,7 @@ jobs:
   sync-labels:
     name: Synchronize labels
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
     - name: Checkout
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1

--- a/.github/workflows/update-pr-body.yml
+++ b/.github/workflows/update-pr-body.yml
@@ -3,11 +3,16 @@
     types:
     - opened
     - synchronize
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
 jobs:
   update-body:
     if: contains(github.event.pull_request.body, '<!-- auto-changes-start -->')
     name: Fill auto-changes section
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
     - name: Checkout
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1


### PR DESCRIPTION
Applies the two deterministic rules of annexe [`CI-CD.md`](https://github.com/chrysa/shared-standards/blob/main/standards/annexes/CI-CD.md):

- **CI-030** — every job declares `timeout-minutes:` (set to 30, raise it where the job legitimately runs longer). Without it a hung job holds a runner until the platform cap.
- **CI-031** — every PR-triggered workflow declares a concurrency group. Superseded PR runs are cancelled; **deploy and release workflows queue instead** (`cancel-in-progress: false`) — cancelling a deployment mid-flight is worse than queueing it.

The remaining findings (permissions, `secrets: inherit`, action pinning) are judgement calls and are reported by `scripts/ci_annexe_audit.py`, never guessed.