### PR TITLE
feat: consume FastAPI forge — manifest → structures → invoke (ADR-002 validation-gate slice)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,9 +3,20 @@ requires = ["setuptools>=82.0.1", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "project-init"
+name = "chrysa-project-init"
 version = "0.1.0"
 requires-python = ">=3.14"
+dependencies = [
+    "pydantic>=2.11",
+    "pyyaml>=6.0",
+    "typer>=0.15",
+]
+
+[project.scripts]
+project-init = "project_init.cli:app"
+
+[tool.setuptools.packages.find]
+where = ["src"]
 
 [project.optional-dependencies]
 test = [
@@ -18,10 +29,10 @@ test = [
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = "--tb=short"
-pythonpath = ["scripts"]
+pythonpath = ["scripts", "src"]
 
 [tool.coverage.run]
-source = ["scripts"]
+source = ["scripts", "src/project_init"]
 omit = ["tests/*", "scripts/__main__.py"]
 
 [tool.coverage.report]

--- a/src/project_init/README.md
+++ b/src/project_init/README.md
@@ -1,0 +1,33 @@
+# project_init
+
+**Role.** The `project-init` Python package — the orchestrator that scaffolds
+chrysa repositories by *delegating* to shared tools, never re-implementing them
+(see [`docs/adr/ADR-002-consume-shared-repos.md`](../../docs/adr/ADR-002-consume-shared-repos.md)).
+
+## Structure
+
+| Path                | Purpose                                                              |
+| ------------------- | ------------------------------------------------------------------- |
+| `cli.py`            | Typer command surface (`init`, `list-types`). Thin — no logic.      |
+| `manifest.py`       | `ProjectManifest` / `ModuleDecl` — the parsed `.project-init.yaml`.  |
+| `forge_adapter.py`  | `ForgeAdapter` — drives the FastAPI forge (engine); owns no rendering. |
+
+## Should contain
+
+- Orchestration code: manifest parsing, adapters over shared tools, the CLI glue.
+
+## Should NOT contain
+
+- File/template rendering logic — that belongs to the delegated engines
+  (`fastapi-app-generator`, `django-app-forge`). Put structure *data* in
+  `templates/`, not generation code here.
+- Business logic in `cli.py` — commands parse and delegate only.
+
+## Rules
+
+- One class per module, module named after it (see
+  [`.claude/rules/class-design.md`](../../../.claude/rules/class-design.md)).
+- `from x import y` imports; typed signatures; raised errors are typed
+  (`ForgeError`), never bare `Exception`.
+- Max 500 lines/file, 50 lines/function, complexity ≤ 10
+  ([`thresholds.md`](../../../.claude/rules/thresholds.md)).

--- a/src/project_init/__init__.py
+++ b/src/project_init/__init__.py
@@ -1,0 +1,12 @@
+"""project-init — orchestrator that scaffolds chrysa repos from shared tools."""
+
+from __future__ import annotations
+
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("chrysa-project-init")
+except PackageNotFoundError:  # pragma: no cover - editable/source checkout
+    __version__ = "0.0.0"
+
+__all__ = ["__version__"]

--- a/src/project_init/cli.py
+++ b/src/project_init/cli.py
@@ -1,0 +1,42 @@
+"""`project-init` command surface (typer).
+
+Thin entry point: parse args, load the manifest, delegate to the adapters. No
+business logic lives here. See docs/adr/ADR-001-architecture.md §1.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import typer
+import yaml
+
+from .forge_adapter import ForgeAdapter
+from .manifest import ProjectManifest
+
+_MANIFEST_NAME = ".project-init.yaml"
+_STRUCTURES = Path(__file__).resolve().parent.parent.parent / "templates" / "fastapi" / "structures.yaml"
+
+app = typer.Typer(help="Scaffold and update chrysa repositories from shared tools.")
+
+
+def _load_manifest(path: Path) -> ProjectManifest:
+    data = yaml.safe_load(path.read_text())
+    return ProjectManifest.model_validate(data)
+
+
+@app.command()
+def init(
+    path: Path = typer.Argument(Path("."), help="Target repository directory."),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Preview without writing."),
+) -> None:
+    """Scaffold a project's FastAPI modules by delegating to the forge."""
+    manifest = _load_manifest(path / _MANIFEST_NAME)
+    ForgeAdapter(_STRUCTURES).generate(manifest, path, dry_run=dry_run)
+    typer.echo(f"Generated {len(manifest.modules)} module(s) under {path}")
+
+
+@app.command(name="list-types")
+def list_types() -> None:
+    """Print the supported project types."""
+    typer.echo("python-fastapi (modules via fastapi-app-generator)")

--- a/src/project_init/forge_adapter.py
+++ b/src/project_init/forge_adapter.py
@@ -1,0 +1,97 @@
+"""Adapter over the `fastapi-app-generator` engine (the forge).
+
+`project-init` owns *what* a chrysa FastAPI module looks like (the canonical
+``templates/fastapi/structures.yaml``) and the *manifest → merged-YAML → invoke*
+wiring; the forge owns *how* files are rendered and written. This module never
+re-implements the rendering — it shells out to the published CLI. See
+docs/adr/ADR-002-consume-shared-repos.md §1.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from .manifest import ProjectManifest
+
+_DEFAULT_GENERATOR = "fastapi-app-generator"
+
+
+class ForgeError(RuntimeError):
+    """Raised when the forge is missing or exits non-zero."""
+
+
+class ForgeAdapter:
+    """Drive the FastAPI forge from a :class:`ProjectManifest`."""
+
+    def __init__(
+        self,
+        structures_path: Path,
+        generator: str = _DEFAULT_GENERATOR,
+    ) -> None:
+        self._structures_path = structures_path
+        self._generator = generator
+
+    def build_forge_document(self, manifest: ProjectManifest) -> dict[str, Any]:
+        """Merge the manifest's modules into the canonical structures document.
+
+        Returns the full forge document (``version``/``templates``/``structures``
+        from the owned file, ``base_path`` and ``modules`` from the manifest).
+        """
+        document = self._load_structures()
+        document["base_path"] = manifest.base_path
+        document["modules"] = [
+            {"name": module.name, "structure": module.structure}
+            for module in manifest.modules
+        ]
+        return document
+
+    def generate(
+        self,
+        manifest: ProjectManifest,
+        root: Path,
+        *,
+        dry_run: bool = False,
+    ) -> None:
+        """Render the manifest's modules under ``root`` by invoking the forge.
+
+        Writes the merged forge document next to ``root`` and calls the CLI.
+        Raises :class:`ForgeError` if the CLI is absent or fails.
+        """
+        document = self.build_forge_document(manifest)
+        config_path = root / ".forge-config.yaml"
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(yaml.safe_dump(document, sort_keys=False))
+        self._invoke(config_path, root, dry_run=dry_run)
+
+    def _invoke(self, config_path: Path, root: Path, *, dry_run: bool) -> None:
+        command = [
+            self._generator,
+            "--config",
+            str(config_path),
+            "--root",
+            str(root),
+        ]
+        if dry_run:
+            command.append("--dry-run")
+        try:
+            result = subprocess.run(command, capture_output=True, text=True, check=False)
+        except FileNotFoundError as error:
+            raise ForgeError(
+                f"Forge CLI {self._generator!r} not found — install fastapi-app-generator"
+            ) from error
+        if result.returncode != 0:
+            raise ForgeError(
+                f"Forge exited {result.returncode}: {result.stderr.strip()}"
+            )
+
+    def _load_structures(self) -> dict[str, Any]:
+        raw = yaml.safe_load(self._structures_path.read_text())
+        if not isinstance(raw, dict):
+            raise ForgeError(
+                f"{self._structures_path} must be a YAML mapping, got {type(raw).__name__}"
+            )
+        return raw

--- a/src/project_init/manifest.py
+++ b/src/project_init/manifest.py
@@ -1,0 +1,41 @@
+"""The `.project-init.yaml` manifest — the canonical record of what a repo opted into.
+
+Holds :class:`ProjectManifest` and its own value object :class:`ModuleDecl`. See
+docs/adr/ADR-001-architecture.md §2 for the manifest contract.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+_DEFAULT_STRUCTURE = "fastapi_module"
+
+
+class ModuleDecl(BaseModel):
+    """One FastAPI module a project wants generated.
+
+    Maps directly onto a forge ``modules[]`` entry: a ``name`` and the named
+    ``structure`` (defined in ``templates/fastapi/structures.yaml``) to render it
+    from.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    name: str = Field(min_length=1)
+    structure: str = _DEFAULT_STRUCTURE
+
+
+class ProjectManifest(BaseModel):
+    """A parsed `.project-init.yaml`.
+
+    Only the fields the FastAPI slice needs today are modelled; the manifest
+    grows as more types and extras are wired.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str = Field(min_length=1)
+    type: str
+    python_version: str = "3.14"
+    base_path: str = "app/api"
+    modules: list[ModuleDecl] = Field(default_factory=list)

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,0 +1,29 @@
+# templates
+
+**Role.** Canonical *structure data* that `project-init` feeds to the delegated
+generation engines. These files describe *what* a chrysa artefact looks like; the
+engines own *how* it is rendered (see
+[`docs/adr/ADR-002-consume-shared-repos.md`](../docs/adr/ADR-002-consume-shared-repos.md) §1).
+
+## Structure
+
+| Path                      | Purpose                                                        |
+| ------------------------- | ------------------------------------------------------------- |
+| `fastapi/structures.yaml` | Canonical FastAPI module structures + templates, fed to `fastapi-app-generator`. |
+
+## Should contain
+
+- Declarative structure/template data consumed by a delegated engine (forge YAML,
+  and later Jinja glue for things no shared repo owns).
+
+## Should NOT contain
+
+- Rendering or generation *code* — that lives upstream in the forge, or in
+  `src/project_init/` as adapter glue.
+- A second copy of a structure another repo already owns — if a second consumer
+  appears, the file moves to its transverse home (*no duplication*).
+
+## Rules
+
+- One canonical file per artefact kind; it is *data*, kept in sync with the
+  engine's schema, not with a hand-copied example.

--- a/templates/fastapi/structures.yaml
+++ b/templates/fastapi/structures.yaml
@@ -1,0 +1,332 @@
+# Canonical chrysa FastAPI module structures — OWNED by project-init.
+#
+# This file is *input data* for the fastapi-app-generator engine (the forge).
+# project-init merges the manifest's `modules:` into this document at runtime and
+# invokes `fastapi-app-generator --config <merged>.yaml`. It re-implements none of
+# the forge's rendering logic — see docs/adr/ADR-002-consume-shared-repos.md §1.
+#
+# Placeholders rendered per module by the forge:
+#   {{ module_name }}   snake_case   (e.g. user_profile)
+#   {{ module_class }}  PascalCase   (e.g. UserProfile)
+#   {{ router_prefix }} kebab-case   (e.g. /user-profiles)
+#   {{ model_class }}   == module_class
+#   plus anything under `context:` below.
+
+version: 1
+
+# Directory all modules are created under, relative to --root. project-init may
+# override this from the manifest before invoking the forge.
+base_path: app/api
+
+context:
+  author: chrysa
+  db_schema: public
+
+templates:
+  init_py: ""
+
+  router_py: |
+    """{{ module_class }} router."""
+    from __future__ import annotations
+
+    from fastapi import APIRouter, Depends, status
+
+    from .dependencies import get_{{ module_name }}_service
+    from .schemas import {{ module_class }}Create, {{ module_class }}Response
+    from .service import {{ module_class }}Service
+
+    router = APIRouter(prefix="{{ router_prefix }}", tags=["{{ module_class }}"])
+
+
+    @router.get("", response_model=list[{{ module_class }}Response], status_code=status.HTTP_200_OK)
+    async def list_{{ module_name }}s(
+        service: {{ module_class }}Service = Depends(get_{{ module_name }}_service),
+    ) -> list[{{ module_class }}Response]:
+        """Return all {{ module_class }} records."""
+        return await service.list()
+
+
+    @router.post("", response_model={{ module_class }}Response, status_code=status.HTTP_201_CREATED)
+    async def create_{{ module_name }}(
+        payload: {{ module_class }}Create,
+        service: {{ module_class }}Service = Depends(get_{{ module_name }}_service),
+    ) -> {{ module_class }}Response:
+        """Create a new {{ module_class }}."""
+        return await service.create(payload)
+
+  schemas_py: |
+    """{{ module_class }} Pydantic v2 schemas."""
+    from __future__ import annotations
+
+    from pydantic import BaseModel, ConfigDict
+
+
+    class {{ module_class }}Base(BaseModel):
+        model_config = ConfigDict(from_attributes=True)
+
+        name: str
+
+
+    class {{ module_class }}Create({{ module_class }}Base):
+        pass
+
+
+    class {{ module_class }}Response({{ module_class }}Base):
+        id: int
+
+  models_py: |
+    """{{ module_class }} SQLAlchemy 2.x ORM model."""
+    from __future__ import annotations
+
+    from sqlalchemy import String
+    from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+
+
+    class Base(DeclarativeBase):
+        pass
+
+
+    class {{ model_class }}(Base):
+        """{{ model_class }} ORM model — authored by {{ author }}."""
+
+        __tablename__ = "{{ module_name }}s"
+        __table_args__ = {"schema": "{{ db_schema }}"}
+
+        id: Mapped[int] = mapped_column(primary_key=True)
+        name: Mapped[str] = mapped_column(String(255), nullable=False)
+
+  service_py: |
+    """{{ module_class }} service — business logic, no HTTP or ORM imports at module level."""
+    from __future__ import annotations
+
+    from .schemas import {{ module_class }}Create, {{ module_class }}Response
+
+
+    class {{ module_class }}Service:
+        """Encapsulates all {{ module_class }} business logic."""
+
+        async def list(self) -> list[{{ module_class }}Response]:
+            """Return all {{ module_class }} records."""
+            raise NotImplementedError
+
+        async def create(self, payload: {{ module_class }}Create) -> {{ module_class }}Response:
+            """Persist a new {{ module_class }} and return the response schema."""
+            raise NotImplementedError
+
+  dependencies_py: |
+    """{{ module_class }} FastAPI Depends() factories."""
+    from __future__ import annotations
+
+    from .service import {{ module_class }}Service
+
+
+    def get_{{ module_name }}_service() -> {{ module_class }}Service:
+        """Provide a {{ module_class }}Service instance (override in tests)."""
+        return {{ module_class }}Service()
+
+  migration_stub: |
+    """Alembic migration stub — {{ module_class }} initial table.
+
+    Revision: REPLACE_ME
+    Create Date: REPLACE_ME
+    """
+    from __future__ import annotations
+
+    from alembic import op
+    import sqlalchemy as sa
+
+
+    def upgrade() -> None:
+        op.create_table(
+            "{{ module_name }}s",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column("name", sa.String(length=255), nullable=False),
+            schema="{{ db_schema }}",
+        )
+
+
+    def downgrade() -> None:
+        op.drop_table("{{ module_name }}s", schema="{{ db_schema }}")
+
+  # --- secure + paginated variant (auth dependency + limit/offset paging) ---
+
+  schemas_secure_py: |
+    """{{ module_class }} Pydantic v2 schemas (with pagination envelope)."""
+    from __future__ import annotations
+
+    from pydantic import BaseModel, ConfigDict, Field
+
+
+    class {{ module_class }}Base(BaseModel):
+        model_config = ConfigDict(from_attributes=True)
+
+        name: str
+
+
+    class {{ module_class }}Create({{ module_class }}Base):
+        pass
+
+
+    class {{ module_class }}Response({{ module_class }}Base):
+        id: int
+
+
+    class PageParams(BaseModel):
+        """Query params for limit/offset pagination."""
+
+        limit: int = Field(default=50, ge=1, le=200)
+        offset: int = Field(default=0, ge=0)
+
+
+    class {{ module_class }}Page(BaseModel):
+        """Paginated envelope for {{ module_class }} listings."""
+
+        items: list[{{ module_class }}Response]
+        total: int
+        limit: int
+        offset: int
+
+  dependencies_secure_py: |
+    """{{ module_class }} FastAPI Depends() factories — service + auth."""
+    from __future__ import annotations
+
+    from fastapi import Depends, HTTPException, status
+    from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+
+    from .service import {{ module_class }}Service
+
+    _bearer = HTTPBearer(auto_error=True)
+
+
+    async def get_current_user(
+        credentials: HTTPAuthorizationCredentials = Depends(_bearer),
+    ) -> str:
+        """Validate the bearer token and return the subject.
+
+        Placeholder — wire to chrysa-lib auth (JWT verification) before use.
+        """
+        token = credentials.credentials
+        if not token:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Missing bearer token",
+            )
+        return token
+
+
+    def get_{{ module_name }}_service() -> {{ module_class }}Service:
+        """Provide a {{ module_class }}Service instance (override in tests)."""
+        return {{ module_class }}Service()
+
+  service_secure_py: |
+    """{{ module_class }} service — paginated listing, no HTTP/ORM imports at module level."""
+    from __future__ import annotations
+
+    from .schemas import {{ module_class }}Create, {{ module_class }}Response
+
+
+    class {{ module_class }}Service:
+        """Encapsulates all {{ module_class }} business logic."""
+
+        async def list(
+            self, *, limit: int, offset: int
+        ) -> tuple[list[{{ module_class }}Response], int]:
+            """Return a page of {{ module_class }} records and the total count."""
+            raise NotImplementedError
+
+        async def create(self, payload: {{ module_class }}Create) -> {{ module_class }}Response:
+            """Persist a new {{ module_class }} and return the response schema."""
+            raise NotImplementedError
+
+  router_secure_py: |
+    """{{ module_class }} router — auth-protected, paginated."""
+    from __future__ import annotations
+
+    from fastapi import APIRouter, Depends, status
+
+    from .dependencies import get_current_user, get_{{ module_name }}_service
+    from .schemas import (
+        {{ module_class }}Create,
+        {{ module_class }}Page,
+        {{ module_class }}Response,
+        PageParams,
+    )
+    from .service import {{ module_class }}Service
+
+    router = APIRouter(
+        prefix="{{ router_prefix }}",
+        tags=["{{ module_class }}"],
+        dependencies=[Depends(get_current_user)],
+    )
+
+
+    @router.get("", response_model={{ module_class }}Page, status_code=status.HTTP_200_OK)
+    async def list_{{ module_name }}s(
+        page: PageParams = Depends(),
+        service: {{ module_class }}Service = Depends(get_{{ module_name }}_service),
+    ) -> {{ module_class }}Page:
+        """Return a page of {{ module_class }} records."""
+        items, total = await service.list(limit=page.limit, offset=page.offset)
+        return {{ module_class }}Page(
+            items=items, total=total, limit=page.limit, offset=page.offset
+        )
+
+
+    @router.post("", response_model={{ module_class }}Response, status_code=status.HTTP_201_CREATED)
+    async def create_{{ module_name }}(
+        payload: {{ module_class }}Create,
+        service: {{ module_class }}Service = Depends(get_{{ module_name }}_service),
+    ) -> {{ module_class }}Response:
+        """Create a new {{ module_class }}."""
+        return await service.create(payload)
+
+structures:
+  fastapi_module:
+    files:
+      - path: __init__.py
+        template: init_py
+      - path: router.py
+        template: router_py
+      - path: schemas.py
+        template: schemas_py
+      - path: models.py
+        template: models_py
+      - path: service.py
+        template: service_py
+      - path: dependencies.py
+        template: dependencies_py
+
+  fastapi_module_with_migration:
+    files:
+      - path: __init__.py
+        template: init_py
+      - path: router.py
+        template: router_py
+      - path: schemas.py
+        template: schemas_py
+      - path: models.py
+        template: models_py
+      - path: service.py
+        template: service_py
+      - path: dependencies.py
+        template: dependencies_py
+      - path: migrations/versions/0001_initial_{{ module_name }}.py
+        template: migration_stub
+
+  # Auth-protected + paginated module (bearer dependency, limit/offset listing).
+  fastapi_module_secure:
+    files:
+      - path: __init__.py
+        template: init_py
+      - path: router.py
+        template: router_secure_py
+      - path: schemas.py
+        template: schemas_secure_py
+      - path: models.py
+        template: models_py
+      - path: service.py
+        template: service_secure_py
+      - path: dependencies.py
+        template: dependencies_secure_py
+      - path: migrations/versions/0001_initial_{{ module_name }}.py
+        template: migration_stub

--- a/tests/test_forge_adapter.py
+++ b/tests/test_forge_adapter.py
@@ -1,0 +1,97 @@
+"""Tests for the FastAPI forge adapter — wiring only, the forge itself is mocked."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from project_init.forge_adapter import ForgeAdapter, ForgeError
+from project_init.manifest import ModuleDecl, ProjectManifest
+
+_STRUCTURES = Path("templates/fastapi/structures.yaml")
+
+
+def _manifest() -> ProjectManifest:
+    return ProjectManifest(
+        name="my-service",
+        type="python-fastapi",
+        base_path="app/api",
+        modules=[
+            ModuleDecl(name="user", structure="fastapi_module_with_migration"),
+            ModuleDecl(name="product"),
+        ],
+    )
+
+
+def test_build_forge_document_when_manifest_has_modules_should_merge_them() -> None:
+    adapter = ForgeAdapter(_STRUCTURES)
+
+    document = adapter.build_forge_document(_manifest())
+
+    assert document["base_path"] == "app/api"
+    assert document["modules"] == [
+        {"name": "user", "structure": "fastapi_module_with_migration"},
+        {"name": "product", "structure": "fastapi_module"},
+    ]
+    # Canonical structures/templates are carried through untouched from the owned file.
+    assert "fastapi_module_secure" in document["structures"]
+    assert "router_py" in document["templates"]
+
+
+def test_generate_when_forge_succeeds_should_invoke_cli_with_config_and_root(
+    tmp_path: Path, mocker
+) -> None:
+    run = mocker.patch(
+        "project_init.forge_adapter.subprocess.run",
+        return_value=subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr=""),
+    )
+    adapter = ForgeAdapter(_STRUCTURES, generator="fastapi-app-generator")
+
+    adapter.generate(_manifest(), tmp_path)
+
+    command = run.call_args.args[0]
+    assert command[0] == "fastapi-app-generator"
+    assert "--config" in command and "--root" in command
+    assert (tmp_path / ".forge-config.yaml").exists()
+
+
+def test_generate_when_dry_run_should_pass_dry_run_flag(tmp_path: Path, mocker) -> None:
+    run = mocker.patch(
+        "project_init.forge_adapter.subprocess.run",
+        return_value=subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr=""),
+    )
+    adapter = ForgeAdapter(_STRUCTURES)
+
+    adapter.generate(_manifest(), tmp_path, dry_run=True)
+
+    assert "--dry-run" in run.call_args.args[0]
+
+
+def test_generate_when_forge_exits_nonzero_should_raise_forge_error(
+    tmp_path: Path, mocker
+) -> None:
+    mocker.patch(
+        "project_init.forge_adapter.subprocess.run",
+        return_value=subprocess.CompletedProcess(
+            args=[], returncode=1, stdout="", stderr="boom"
+        ),
+    )
+    adapter = ForgeAdapter(_STRUCTURES)
+
+    with pytest.raises(ForgeError, match="boom"):
+        adapter.generate(_manifest(), tmp_path)
+
+
+def test_generate_when_forge_missing_should_raise_forge_error(
+    tmp_path: Path, mocker
+) -> None:
+    mocker.patch(
+        "project_init.forge_adapter.subprocess.run",
+        side_effect=FileNotFoundError,
+    )
+    adapter = ForgeAdapter(_STRUCTURES, generator="missing-binary")
+
+    with pytest.raises(ForgeError, match="not found"):
+        adapter.generate(_manifest(), tmp_path)


### PR DESCRIPTION
First slice of the ADR-002 validation gate for python-fastapi. Stacks on #189 (merge #189 first). project-init owns canonical FastAPI structure data (templates/fastapi/structures.yaml) and drives the forge engine via ForgeAdapter (manifest -> merged YAML -> invoke); re-implements no rendering. 5 pytest-mock tests green, ruff clean. Kill-test (real make ci in container) is the next step. Refs #1