### PR TITLE
chore(ape): fix ape_hook.py template (drop unused json import)

### DIFF
--- a/.claude/ape/ape_hook.py
+++ b/.claude/ape/ape_hook.py
@@ -18,7 +18,6 @@ context to stdout, which Claude Code injects before the turn.
 """
 import sys
 import re
-import json
 import argparse
 
 # --- fast triage: is this prompt worth optimizing at all? ---


### PR DESCRIPTION
The scaffolded `.claude/ape/ape_hook.py` template carried an unused `import json` (ruff F401) + unsorted imports. Consumer repos had already fixed their local copy (verified across ai-aggregator/claude-config/dotfiles/mirrador/server), so the **template was the drift source**, not the repos. Syncing the template forward fixes the fleet-wide lint noise at the root (audit 2026-08-09).

🤖 Generated with [Claude Code](https://claude.com/claude-code)